### PR TITLE
allow driver to cancel old plan [WIP]

### DIFF
--- a/include/franka_plan_runner.h
+++ b/include/franka_plan_runner.h
@@ -710,8 +710,11 @@ private:
         if (current_mode == franka::RobotMode::kIdle) {
             return true;
         }
+        if (current_mode == franka::RobotMode::kMove) {
+            return true;
+        }
+        momap::log()->error("CanReceiveCommands: Wrong mode! Current Mode is: {}", RobotModeToString(current_mode));
 
-        momap::log()->error("CanReceiveCommands: Wrong mode!");
         return false;
     }
 


### PR DESCRIPTION
allow kMove as a current mode for accepting new plans, needed to unpause a robot through sending a new motion plan