### PR TITLE
Do not prompt before killing existing robot driver app

### DIFF
--- a/src/franka_driver.cc
+++ b/src/franka_driver.cc
@@ -24,7 +24,9 @@ int do_main(std::string param_yaml = "franka_test.yaml") {
 int main(int argc, char** argv) {
   // Ensure app is singleton (added by 5yler):
   std::string pid_file = "/var/run/cobot_driver.pid";
-  if (!dru::lock_pid_file(pid_file)) {
+  bool kill_existing_process = true;
+  bool prompt_before_kill = false;
+  if (!dru::lock_pid_file(pid_file, kill_existing_process, prompt_before_kill)) {
     std::cerr << "Failed to set up singleton cobot driver app." << std::endl;
     return 1;
   }


### PR DESCRIPTION
Fixes bug where starting a new instance of the driver would not automatically kill the existing one. This resulted in odd behavior with `franka` command where it would only work every other time:
```
root@jaeger:~# franka J
published bool to FRANKA_J_START_DRIVER
waiting on driver response on FRANKA_J_DRIVER_STATUS
utime:  1576451806892675
success:  true
message:  
root@jaeger:~# franka J
published bool to FRANKA_J_START_DRIVER
waiting on driver response on FRANKA_J_DRIVER_STATUS
no message received from driver after 5.0 seconds
is the NUC on and properly wired?
root@jaeger:~# franka J
published bool to FRANKA_J_START_DRIVER
waiting on driver response on FRANKA_J_DRIVER_STATUS
utime:  1576451873884790
success:  true
message:  
root@jaeger:~# franka J
published bool to FRANKA_J_START_DRIVER
waiting on driver response on FRANKA_J_DRIVER_STATUS
no message received from driver after 5.0 seconds
is the NUC on and properly wired?
```

Tested on the robot.