### PR TITLE
Sw.user stop.broadcast

### DIFF
--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -116,6 +116,7 @@ class CommunicationInterface {
 
   std::string lcm_driver_status_channel_;
   std::string lcm_pause_status_channel_;
+  std::string lcm_user_stop_channel_;
   double lcm_publish_rate_;  // Hz
 };
 

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -217,6 +217,7 @@ void CommunicationInterface::PublishRobotStatus() {
     lock.unlock();
 
     robot_msgs::bool_t user_stop_status;
+    user_stop_status.utime = franka_status.utime;
     user_stop_status.data = current_mode == franka::RobotMode::kUserStopped;
     lcm_.publish(params_.lcm_status_channel, &franka_status);
     lcm_.publish(lcm_user_stop_channel_, &user_stop_status);


### PR DESCRIPTION
### Background

- Broadcast user stop status as a bool

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### TODOs / Nice-To-Haves
- ❌  Combine user stop status, estop status, robot status into single message definition

### Tests
1. ✅ Tested on simulated robot: Ran franka driver, verified topic being published
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
