### PR TITLE
Add communication_test to be build by default

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -68,7 +68,7 @@ if [ ! -f "build/libfranka.so" ]; then
                  -DCMAKE_C_COMPILER=gcc-7 \
                  -DCMAKE_CXX_COMPILER=g++-7
     fi
-    cmake --build . -j $num_threads --target franka
+    cmake --build . -j $num_threads --target franka communication_test
     popd
 fi
 


### PR DESCRIPTION
### Background
Add communication_test to be build when setup.sh is called.  Building all targets was much slower.

### What's new
Add communication_test to be build when setup.sh is called.

### Tests
1. ✅ Tested on simulated robot: Ran build, verified communication_test was built
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ❌ I have included Doxygen-style documentation in the new C++ code. (not needed)

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
