### PR TITLE
Publish DRIVER_STATUS false if unable to receive commands

### DIFF
--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -95,7 +95,7 @@ class CommunicationInterface {
                                bool success = true, std::string message = "");
   /// check if robot is in a mode that can receive commands, i.e. not user
   /// stopped or error recovery
-  bool CanReceiveCommands(const franka::RobotMode&);
+  bool CanReceiveCommands(const franka::RobotMode& current_mode);
   void HandlePlan(const ::lcm::ReceiveBuffer*, const std::string&,
                   const lcmtypes::robot_spline_t* robot_spline);
   void HandlePause(const ::lcm::ReceiveBuffer*, const std::string&,

--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -62,6 +62,10 @@ class CommunicationInterface {
 
   // TODO: remove franka specific RobotState type and replace with std::array
   franka::RobotState GetRobotState();
+
+  // acquire mutex lock and return robot mode
+  franka::RobotMode GetRobotMode();
+
   /// Blocking call that sets the robot state
   void SetRobotData(const franka::RobotState& robot_state,
                     const Eigen::VectorXd& robot_plan_next_conf);
@@ -91,7 +95,7 @@ class CommunicationInterface {
                                bool success = true, std::string message = "");
   /// check if robot is in a mode that can receive commands, i.e. not user
   /// stopped or error recovery
-  bool CanReceiveCommands();
+  bool CanReceiveCommands(const franka::RobotMode&);
   void HandlePlan(const ::lcm::ReceiveBuffer*, const std::string&,
                   const lcmtypes::robot_spline_t* robot_spline);
   void HandlePause(const ::lcm::ReceiveBuffer*, const std::string&,

--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -121,6 +121,8 @@ class CommunicationInterface {
   std::string lcm_driver_status_channel_;
   std::string lcm_pause_status_channel_;
   std::string lcm_user_stop_channel_;
+  std::string lcm_brakes_locked_channel_;
+
   double lcm_publish_rate_;  // Hz
 };
 

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -43,6 +43,7 @@ CommunicationInterface::CommunicationInterface(const RobotParameters params,
   // TODO: remove these channels by combining it with the robot status channel
   lcm_pause_status_channel_ = params_.robot_name + "_PAUSE_STATUS";
   lcm_user_stop_channel_ = params_.robot_name + "_USER_STOPPED";
+  lcm_brakes_locked_channel_ = params_.robot_name + "_BRAKES_LOCKED";
 
   dexai::log()->info("Plan channel:          {}", params_.lcm_plan_channel);
   dexai::log()->info("Stop channel:          {}", params_.lcm_stop_channel);
@@ -219,8 +220,14 @@ void CommunicationInterface::PublishRobotStatus() {
     robot_msgs::bool_t user_stop_status;
     user_stop_status.utime = franka_status.utime;
     user_stop_status.data = current_mode == franka::RobotMode::kUserStopped;
+
+    robot_msgs::bool_t brakes_locked_status;
+    brakes_locked_status.utime = franka_status.utime;
+    brakes_locked_status.data = current_mode == franka::RobotMode::kOther;
+
     lcm_.publish(params_.lcm_status_channel, &franka_status);
     lcm_.publish(lcm_user_stop_channel_, &user_stop_status);
+    lcm_.publish(lcm_brakes_locked_channel_, &brakes_locked_status);
   } else {
     lock.unlock();
   }

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -254,7 +254,7 @@ void CommunicationInterface::PublishTriggerToChannel(int64_t utime,
 }
 
 franka::RobotMode CommunicationInterface::GetRobotMode() {
-  std::lock_guard<std::mutex> lock(robot_data_mutex_);
+  std::scoped_lock<std::mutex> lock {robot_data_mutex_};
   return robot_data_.robot_state.robot_mode;
 }
 

--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -558,8 +558,6 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
   Eigen::VectorXd current_conf_franka =
       utils::v_to_e(ArrayToVector(cannonical_robot_state.q_d));
 
-  static bool first_run = true;
-
   if (comm_interface_->HasNewPlan()) {
     // get the current plan from the communication interface
     comm_interface_->TakePlan(plan_, plan_utime_);


### PR DESCRIPTION
### Background
Publish DRIVER_STATUS if franka brakes are locked

### What's new
- ✅ Publish DRIVER_STATUS false if franka brakes are locked and driver is unable to accept plans
- ✅ Publish a bool <robot>_BRAKES_LOCKED status

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
