### PR TITLE
Retry when attempting to connect to Franka for first time

### DIFF
--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -162,7 +162,7 @@ int FrankaPlanRunner::RunFranka() {
     try {
       franka::Robot robot(ip_addr_);
 
-      auto current_mode = GetRobotMode(robot);
+      auto current_mode {GetRobotMode(robot)};
 
       // if in reflex mode, attempt automatic error recovery
       if (current_mode == franka::RobotMode::kReflex) {

--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -183,10 +183,15 @@ int FrankaPlanRunner::RunFranka() {
           comm_interface_->PublishDriverStatus(false, ce.what());
           continue;
         }
+      } else if (current_mode != franka::RobotMode::kIdle) {
+        auto err_msg {
+            fmt::format("Robot cannot receive commands in mode {}", e.what())};
+        dexai::log()->error("RunFranka: {}", err_msg);
+        comm_interface_->PublishDriverStatus(false, err_msg);
+      } else {
+        // if we got this far, we are talking to the Franka and it is happy
+        connection_established = true;
       }
-      // if we got this far, we are talking to the Franka and it is happy
-      connection_established = true;
-
     } catch (franka::Exception const& e) {
       // if we hit this logic, there is probably something wrong with the
       // networking

--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -155,48 +155,45 @@ franka::RobotMode FrankaPlanRunner::GetRobotMode(franka::Robot& robot) {
 }
 
 int FrankaPlanRunner::RunFranka() {
-  //$ attempt connection to robot and read current mode
-  //$ return if connection fails, or robot is in a mode that cannot receive
-  // commands
-  try {
-    franka::Robot robot(ip_addr_);
+  bool connection_established {false};
+  // attempt connection to robot and read current mode
+  // and if it fails, keep trying instead of exiting the program
+  while (!connection_established) {
+    try {
+      franka::Robot robot(ip_addr_);
 
-    size_t count = 0;
-    auto current_mode = GetRobotMode(robot);
+      auto current_mode = GetRobotMode(robot);
 
-    if (current_mode == franka::RobotMode::kReflex) {
-      dexai::log()->warn(
-          "RunFranka: Robot in mode: {} at startup, trying to do "
-          "automaticErrorRecovery ...",
-          utils::RobotModeToString(current_mode));
-      try {
-        robot.automaticErrorRecovery();
-        dexai::log()->info(
-            "RunFranka: automaticErrorRecovery() succeeded, "
-            "robot now in mode: {}.",
+      // if in reflex mode, attempt automatic error recovery
+      if (current_mode == franka::RobotMode::kReflex) {
+        dexai::log()->warn(
+            "RunFranka: Robot in mode: {} at startup, trying to do "
+            "automaticErrorRecovery ...",
             utils::RobotModeToString(current_mode));
-      } catch (const franka::ControlException& ce) {
-        dexai::log()->warn("RunFranka: Caught control exception: {}.",
-                           ce.what());
-        dexai::log()->error("RunFranka: Error recovery did not work!");
-        comm_interface_->PublishDriverStatus(false, ce.what());
-        return 1;
+        try {
+          robot.automaticErrorRecovery();
+          dexai::log()->info(
+              "RunFranka: automaticErrorRecovery() succeeded, "
+              "robot now in mode: {}.",
+              utils::RobotModeToString(current_mode));
+        } catch (const franka::ControlException& ce) {
+          dexai::log()->warn("RunFranka: Caught control exception: {}.",
+                             ce.what());
+          dexai::log()->error("RunFranka: Error recovery did not work!");
+          comm_interface_->PublishDriverStatus(false, ce.what());
+          continue;
+        }
       }
-    } else if (current_mode != franka::RobotMode::kIdle) {
-      dexai::log()->error(
-          "RunFranka: Robot cannot receive commands in mode: {}",
-          utils::RobotModeToString(current_mode));
-      comm_interface_->PublishDriverStatus(
-          false, utils::RobotModeToString(current_mode));
-      return 1;
+      // if we got this far, we are talking to the Franka and it is happy
+      connection_established = true;
+
+    } catch (franka::Exception const& e) {
+      // if we hit this logic, there is probably something wrong with the
+      // networking
+      auto err_msg {fmt::format("Franka connection error: {}", e.what())};
+      dexai::log()->error("RunFranka: {}", err_msg);
+      comm_interface_->PublishDriverStatus(false, err_msg);
     }
-  } catch (franka::Exception const& e) {
-    dexai::log()->error(
-        "RunFranka: Received franka exception: {} - Do not have error handling "
-        "for it yet...",
-        e.what());
-    comm_interface_->PublishDriverStatus(false, e.what());
-    return 1;
   }
 
   try {

--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -199,6 +199,7 @@ int FrankaPlanRunner::RunFranka() {
       dexai::log()->error("RunFranka: {}", err_msg);
       comm_interface_->PublishDriverStatus(false, err_msg);
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
 
   try {

--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -184,8 +184,8 @@ int FrankaPlanRunner::RunFranka() {
           continue;
         }
       } else if (current_mode != franka::RobotMode::kIdle) {
-        auto err_msg {
-            fmt::format("Robot cannot receive commands in mode {}", e.what())};
+        auto err_msg {fmt::format("Robot cannot receive commands in mode {}",
+                                  utils::RobotModeToString(current_mode))};
         dexai::log()->error("RunFranka: {}", err_msg);
         comm_interface_->PublishDriverStatus(false, err_msg);
       } else {

--- a/src/util_conv.cc
+++ b/src/util_conv.cc
@@ -16,7 +16,7 @@ std::string RobotModeToString(franka::RobotMode mode) {
   std::string mode_string;
   switch (mode) {
     case franka::RobotMode::kOther:
-      mode_string = "Other";
+      mode_string = "Locked";
       break;
     case franka::RobotMode::kIdle:
       mode_string = "Idle";


### PR DESCRIPTION
### Background

- This prevents us from bailing early and creating unnecessary duplicate logs each time driver fails to start. Just keep trying...

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ✅Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: Tried starting up while user stopped or not connected to franka, verified it keeps retrying until connection can be established

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
