### PR TITLE
Check if user stopped on startup

### DIFF
--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -80,6 +80,10 @@ class CommunicationInterface {
                            std::string driver_status_string = "");
 
   void PublishDriverStatus(bool success, std::string driver_status_string = "");
+  void PublishBoolToChannel(int64_t utime, std::string_view lcm_channel,
+                            bool data);
+
+  std::string GetUserStopChannelName() { return lcm_user_stop_channel_; };
 
  protected:
   void ResetData();
@@ -91,8 +95,9 @@ class CommunicationInterface {
   void PublishLcmAndPauseStatus();
   void PublishRobotStatus();
   void PublishPauseStatus();
-  void PublishTriggerToChannel(int64_t utime, std::string lcm_channel,
-                               bool success = true, std::string message = "");
+  void PublishTriggerToChannel(int64_t utime, std::string_view lcm_channel,
+                               bool success = true,
+                               std::string_view message = "");
   /// check if robot is in a mode that can receive commands, i.e. not user
   /// stopped or error recovery
   bool CanReceiveCommands(const franka::RobotMode& current_mode);

--- a/src/franka_plan_runner.cc
+++ b/src/franka_plan_runner.cc
@@ -213,6 +213,11 @@ int FrankaPlanRunner::RunFranka() {
                                   utils::RobotModeToString(current_mode))};
         dexai::log()->error("RunFranka: {}", err_msg);
         comm_interface_->PublishDriverStatus(false, err_msg);
+      } else if (current_mode == franka::RobotMode::kUserStopped) {
+        dexai::log()->error("RunFranka: Robot User Stopped");
+        comm_interface_->PublishBoolToChannel(
+            utils::get_current_utime(),
+            comm_interface_->GetUserStopChannelName(), true);
       } else {
         // if we got this far, we are talking to the Franka and it is happy
         connection_established = true;


### PR DESCRIPTION
### Background

Check if the cobot is user stopped on startup

### What's new
- ✅ Check if user stopped on startup, if so send a message

### Tests
1. ✅ Tested on simulated robot: Tested with TLE 
2. ✅ Tested on physical robot: Tested on `krieger` 

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
