### PR TITLE
U-stop pauses all robots

### DIFF
--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -110,7 +110,7 @@ class CommunicationInterface {
   void HandlePause(const ::lcm::ReceiveBuffer*, const std::string&,
                    const robot_msgs::pause_cmd* pause_cmd_msg);
   void HandleUserStop(const ::lcm::ReceiveBuffer*, const std::string&,
-                      const robot_msgs::pause_cmd* user_stop_msg);
+                      const robot_msgs::bool_t* user_stop_msg);
 
  private:
   RobotParameters params_;
@@ -135,7 +135,7 @@ class CommunicationInterface {
 
   std::string lcm_user_stop_channel_;
   std::string sim_u_stop_source;
-  bool sim_u_stop;
+  bool sim_u_stop = false;
 
   double lcm_publish_rate_;  // Hz
 };

--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -136,6 +136,7 @@ class CommunicationInterface {
   std::string lcm_user_stop_channel_;
   std::string sim_u_stop_source;
   bool sim_u_stop = false;
+  bool prev_pause_state = false;
 
   double lcm_publish_rate_;  // Hz
 };

--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -131,8 +131,11 @@ class CommunicationInterface {
 
   std::string lcm_driver_status_channel_;
   std::string lcm_pause_status_channel_;
-  std::string lcm_user_stop_channel_;
   std::string lcm_brakes_locked_channel_;
+
+  std::string lcm_user_stop_channel_;
+  std::string sim_u_stop_source;
+  bool sim_u_stop;
 
   double lcm_publish_rate_;  // Hz
 };

--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -135,8 +135,8 @@ class CommunicationInterface {
 
   std::string lcm_user_stop_channel_;
   std::string sim_u_stop_source;
-  bool sim_u_stop = false;
-  bool prev_pause_state = false;
+  bool sim_u_stop {false};
+  bool prev_pause_state {false};
 
   double lcm_publish_rate_;  // Hz
 };

--- a/include/communication_interface.h
+++ b/include/communication_interface.h
@@ -21,6 +21,7 @@
 #include <lcm/lcm-cpp.hpp>              // for lcm
 #include <lcmtypes/robot_spline_t.hpp>  // for robot_spline_t
 #include <robot_msgs/pause_cmd.hpp>     // for pause_cmd
+#include <robot_msgs/bool_t.hpp>        // for bool_t
 
 #include "drake/common/trajectories/piecewise_polynomial.h"  // for Piecewis...
 #include "franka/robot_state.h"                              // for RobotState
@@ -82,6 +83,9 @@ class CommunicationInterface {
   void PublishDriverStatus(bool success, std::string driver_status_string = "");
   void PublishBoolToChannel(int64_t utime, std::string_view lcm_channel,
                             bool data);
+  void PublishPauseToChannel(int64_t utime, std::string_view lcm_channel,
+                             bool data,
+                             std::string_view source = "");
 
   std::string GetUserStopChannelName() { return lcm_user_stop_channel_; };
 
@@ -105,6 +109,8 @@ class CommunicationInterface {
                   const lcmtypes::robot_spline_t* robot_spline);
   void HandlePause(const ::lcm::ReceiveBuffer*, const std::string&,
                    const robot_msgs::pause_cmd* pause_cmd_msg);
+  void HandleUserStop(const ::lcm::ReceiveBuffer*, const std::string&,
+                      const robot_msgs::pause_cmd* user_stop_msg);
 
  private:
   RobotParameters params_;

--- a/include/robot_parameters.h
+++ b/include/robot_parameters.h
@@ -153,6 +153,7 @@ class RobotParameters {
   std::string lcm_plan_received_channel;
   std::string lcm_plan_complete_channel;
   std::string lcm_stop_channel;
+  std::string lcm_user_stop_channel;
 
   std::string lcm_url;
   std::string robot_ip;

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -428,7 +428,7 @@ void CommunicationInterface::HandlePause(
     const robot_msgs::pause_cmd* pause_cmd_msg) {
   std::lock_guard<std::mutex> lock(pause_mutex_);
 
-  // check if pause cmd command has simulated u-stop source
+  // set simulated U-stop status
   if(pause_cmd_msg->source == sim_u_stop_source){
     dexai::log()->warn(
         "CommunicationInterface::HandlePause: Received simulated_user_stop = {} from {}",
@@ -441,30 +441,38 @@ void CommunicationInterface::HandlePause(
   // check if paused = true or paused = false was received:
   bool paused = pause_cmd_msg->data;
   if (paused) {
-    dexai::log()->warn(
+    if(prev_pause_state != paused){
+      dexai::log()->warn(
         "CommunicationInterface::HandlePause: Received 'pause = true' from {}",
         pause_cmd_msg->source);
+    }
     if (pause_data_.pause_sources_set_.insert(pause_cmd_msg->source).second
         == false) {
-      dexai::log()->warn(
+      if(prev_pause_state != paused){
+        dexai::log()->warn(
           "CommunicationInterface::HandlePause: "
           "Already paused by source: {}",
           pause_cmd_msg->source);
+      }
     }
   } else {
-    dexai::log()->warn(
+    if(prev_pause_state != paused){
+      dexai::log()->warn(
         "CommunicationInterface::HandlePause: Received 'pause = false' from {}",
         pause_cmd_msg->source);
+    }
     if (pause_data_.pause_sources_set_.find(pause_cmd_msg->source)
         != pause_data_.pause_sources_set_.end()) {
       pause_data_.pause_sources_set_.erase(pause_cmd_msg->source);
-    } else {
-      dexai::log()->warn(
+    } else if (prev_pause_state != paused) {
+        dexai::log()->warn(
           "Unpausing command rejected: No matching "
           "pause command by source: {}'",
           pause_cmd_msg->source);
     }
   }
+  // set previous pause state for pause logging
+  prev_pause_state = paused;
 
   // if the set of pause sources is empty, then
   // the robot is not paused anymore:
@@ -475,6 +483,7 @@ void CommunicationInterface::HandlePause(
   }
 }
 
+// Publish to pause depending on the User Stop status
 void CommunicationInterface::HandleUserStop(
     const ::lcm::ReceiveBuffer*, const std::string&,
     const robot_msgs::bool_t* user_stop_msg) {

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -46,7 +46,7 @@ CommunicationInterface::CommunicationInterface(const RobotParameters params,
   lcm_pause_status_channel_ = params_.robot_name + "_PAUSE_STATUS";
   lcm_user_stop_channel_ = params_.robot_name + "_USER_STOPPED";
   lcm_brakes_locked_channel_ = params_.robot_name + "_BRAKES_LOCKED";
-  sim_u_stop_source = params_.robot_name + "_SIMULATED_U_STOP";
+  sim_u_stop_source = params_.robot_name + "_SIM_U_STOP";
 
   dexai::log()->info("Plan channel:          {}", params_.lcm_plan_channel);
   dexai::log()->info("Stop channel:          {}", params_.lcm_stop_channel);

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -37,6 +37,8 @@ CommunicationInterface::CommunicationInterface(const RobotParameters params,
                  this);
   lcm_.subscribe(params_.lcm_stop_channel, &CommunicationInterface::HandlePause,
                  this);
+  lcm_.subscribe(params_.lcm_user_stop_channel, &CommunicationInterface::HandleUserStop,
+                 this);
 
   // TODO: define this in parameters file
   lcm_driver_status_channel_ = params_.robot_name + "_DRIVER_STATUS";
@@ -47,6 +49,8 @@ CommunicationInterface::CommunicationInterface(const RobotParameters params,
 
   dexai::log()->info("Plan channel:          {}", params_.lcm_plan_channel);
   dexai::log()->info("Stop channel:          {}", params_.lcm_stop_channel);
+  dexai::log()->info("User Stop channel:     {}", 
+                     params_.lcm_user_stop_channel);
   dexai::log()->info("Plan received channel: {}",
                      params_.lcm_plan_received_channel);
   dexai::log()->info("Plan complete channel: {}",
@@ -253,6 +257,17 @@ void CommunicationInterface::PublishTriggerToChannel(
   lcm_.publish(lcm_channel.data(), &msg);
 }
 
+void CommunicationInterface::PublishPauseToChannel(int64_t utime,
+                                                   std::string_view lcm_channel,
+                                                   bool data,
+                                                   std::string_view source) {
+  robot_msgs::pause_cmd msg;
+  msg.utime = utime;
+  msg.data = data;
+  msg.source = source;
+  lcm_.publish(lcm_channel.data(), &msg);
+}
+
 void CommunicationInterface::PublishBoolToChannel(int64_t utime,
                                                   std::string_view lcm_channel,
                                                   bool data) {
@@ -436,4 +451,15 @@ void CommunicationInterface::HandlePause(
   } else {
     pause_data_.paused_ = true;
   }
+}
+
+
+void CommunicationInterface::HandleUserStop(
+    const ::lcm::ReceiveBuffer*, const std::string&,
+    const robot_msgs::pause_cmd* user_stop_msg) {
+
+  PublishPauseToChannel(utils::get_current_utime(),
+                       lcm_user_stop_channel_,
+                       user_stop_msg->data, 
+                       user_stop_msg->source);
 }

--- a/src/communication_interface.cc
+++ b/src/communication_interface.cc
@@ -46,6 +46,7 @@ CommunicationInterface::CommunicationInterface(const RobotParameters params,
   lcm_pause_status_channel_ = params_.robot_name + "_PAUSE_STATUS";
   lcm_user_stop_channel_ = params_.robot_name + "_USER_STOPPED";
   lcm_brakes_locked_channel_ = params_.robot_name + "_BRAKES_LOCKED";
+  sim_u_stop_source = params_.robot_name + "_SIMULATED_USER_STOP";
 
   dexai::log()->info("Plan channel:          {}", params_.lcm_plan_channel);
   dexai::log()->info("Stop channel:          {}", params_.lcm_stop_channel);
@@ -222,8 +223,19 @@ void CommunicationInterface::PublishRobotStatus() {
     lock.unlock();
 
     lcm_.publish(params_.lcm_status_channel, &franka_status);
-    PublishBoolToChannel(franka_status.utime, lcm_user_stop_channel_,
-                         current_mode == franka::RobotMode::kUserStopped);
+    // publish true to user_stop_channel if U-stop is simulated
+    if(sim_u_stop){
+      PublishPauseToChannel(franka_status.utime, lcm_user_stop_channel_,
+                            true, sim_u_stop_source);
+    }
+    // otherwise publish current franka U-stop status
+    else{
+      PublishPauseToChannel(franka_status.utime, lcm_user_stop_channel_,
+                            current_mode == franka::RobotMode::kUserStopped,
+                            params_.robot_name);
+    }
+    // PublishBoolToChannel(franka_status.utime, lcm_user_stop_channel_,
+                        //  current_mode == franka::RobotMode::kUserStopped);
     PublishBoolToChannel(franka_status.utime, lcm_brakes_locked_channel_,
                          current_mode == franka::RobotMode::kOther);
   } else {
@@ -416,6 +428,17 @@ void CommunicationInterface::HandlePause(
     const ::lcm::ReceiveBuffer*, const std::string&,
     const robot_msgs::pause_cmd* pause_cmd_msg) {
   std::lock_guard<std::mutex> lock(pause_mutex_);
+
+  // check if pause cmd command has simulated u-stop source
+  if(pause_cmd_msg->source == sim_u_stop_source){
+    dexai::log()->warn(
+        "CommunicationInterface::HandlePause: Received simulated_user_stop = {} from {}",
+        pause_cmd_msg->data,
+        pause_cmd_msg->source
+    );
+    sim_u_stop = pause_cmd_msg->data;
+    return;
+  }
   // check if paused = true or paused = false was received:
   bool paused = pause_cmd_msg->data;
   if (paused) {
@@ -453,10 +476,14 @@ void CommunicationInterface::HandlePause(
   }
 }
 
-
 void CommunicationInterface::HandleUserStop(
     const ::lcm::ReceiveBuffer*, const std::string&,
     const robot_msgs::pause_cmd* user_stop_msg) {
+
+  dexai::log()->warn(
+      "CommunicationInterface::HandleUserStop: Received 'U-stop = {}' from {}",
+      user_stop_msg->data,
+      user_stop_msg->source);
 
   PublishPauseToChannel(utils::get_current_utime(),
                        lcm_user_stop_channel_,

--- a/src/robot_parameters.cc
+++ b/src/robot_parameters.cc
@@ -104,6 +104,7 @@ bool RobotParameters::GenerateParametersBasedOnRobotName(
   lcm_plan_received_channel = new_robot_name + "_PLAN_RECEIVED";
   lcm_plan_complete_channel = new_robot_name + "_PLAN_COMPLETE";
   lcm_stop_channel = new_robot_name + "_STOP";
+  lcm_user_stop_channel = new_robot_name + "_USER_STOPPED";
 
   return true;
 }
@@ -222,6 +223,7 @@ RobotParameters loadYamlParameters(
     p.lcm_plan_received_channel = p.robot_name + "_PLAN_RECEIVED";
     p.lcm_plan_complete_channel = p.robot_name + "_PLAN_COMPLETE";
     p.lcm_stop_channel = p.robot_name + "_STOP";
+    p.lcm_user_stop_channel = p.robot_name + "_USER_STOPPED";
 
     get_yaml_val_or_die(param, "lcm_url", p.lcm_url, yaml_full_path, verbose,
                         exit_code);


### PR DESCRIPTION
### Background
Implemented U-stop message handler to continually publish to `FRANKA_A_STOP`based on U-stop status. Added simulated U-stop feature, and added pause state checking to prevent driver output spam.

### What's new
- ✅ User-stop lcm message handler added, publishes to pause channel.
- ✅ Pause lcm handler now sets `simulated U-stop`, if `cmd pause FRANKA_A_SIM_U_STOP` and `cmd unpause FRANKA_A_SIM_U_STOP` are run.
- ✅ Robot Status now calls U-Stop handler with the status of either the simulated U-stop, or the robot U-stop, depending on if the simulated U-stop is enabled.
- ✅ Pause handler only prints it's logs if the previous pause state was different than the current one, only prints updates once.

### Related work
- ✅❌ This PR needs 

### TODOs/Nice-To-Haves
- IncreaseFrankaTimeBasedOnStatus still prints quite a few logs, but not continuous, might change

### Tests
1. ✅ Tested on simulated robot: 
- `drake-franka-driver` and `ancillary_arm` were built and started.
- start `back_and_forth`
- call `cmd pause FRANKA_A_SIM_U_STOP` and `cmd unpause FRANKA_A_SIM_U_STOP` to U-stop/pause the robots
2. ❌ Tested on physical robot: 

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
