### PR TITLE
Sw.user stop.debug

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -522,14 +522,14 @@ void CommunicationInterface::HandleSimDriverEventTrigger(
   if (desired_event == "u_stop") {
     std::scoped_lock<std::mutex> lock {robot_data_mutex_};
     if (cmd_msg->data) {
-      dexai::log()->info(
+      dexai::log()->warn(
           "CommInterface:HandleSimDriverEventTrigger: received "
-          "command to simulate U Stop = True");
+          "command to simulate User Stop button press");
       robot_data_.robot_state.robot_mode = franka::RobotMode::kUserStopped;
     } else {
-      dexai::log()->info(
+      dexai::log()->warn(
           "CommInterface:HandleSimDriverEventTrigger: received "
-          "command to simulate U Stop = False");
+          "command to simulate User Stop release");
       robot_data_.robot_state.robot_mode = franka::RobotMode::kIdle;
     }
   } else {

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -578,7 +578,7 @@ void FrankaPlanRunner::IncreaseFrankaTimeBasedOnStatus(
             source);
         comm_interface_->PublishPlanComplete(
             plan_utime_, false,
-            fmt::format("plan canceled after request from source: {}", source));
+            fmt::format("plan canceled upon request from source: {}", source));
         plan_.release();
         plan_utime_ = -1;  // reset plan to -1
       }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -571,11 +571,14 @@ void FrankaPlanRunner::IncreaseFrankaTimeBasedOnStatus(
     // do nothing
     if (cancel_plan_requested) {
       if (plan_) {
+        auto source {comm_interface_->GetCancelPlanSource()};
         dexai::log()->warn(
             "IncreaseFrankaTimeBasedOnStatus: Paused successfully after "
             "cancel plan request from source: {}",
-            comm_interface_->GetCancelPlanSource());
-        comm_interface_->PublishPlanComplete(plan_utime_, false, "canceled");
+            source);
+        comm_interface_->PublishPlanComplete(
+            plan_utime_, false,
+            fmt::format("plan canceled after request from source: {}", source));
         plan_.release();
         plan_utime_ = -1;  // reset plan to -1
       }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -367,7 +367,6 @@ int FrankaPlanRunner::RunSim() {
   Eigen::VectorXd prev_conf(dof_);
   std::vector<double> vel(7, 1);
   franka::RobotState robot_state;  // internal state; mapping to franka state
-
   franka::Duration period;
   std::chrono::milliseconds last_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -367,7 +367,6 @@ int FrankaPlanRunner::RunSim() {
   Eigen::VectorXd prev_conf(dof_);
   std::vector<double> vel(7, 1);
   franka::RobotState robot_state;  // internal state; mapping to franka state
-  robot_state.robot_mode = franka::RobotMode::kIdle;
 
   franka::Duration period;
   std::chrono::milliseconds last_ms =


### PR DESCRIPTION
### Background

- Fix sim franka initializing to user stopped: offending code was 
```c++
void CommunicationInterface::ResetData() {
  std::unique_lock<std::mutex> lock_data(robot_data_mutex_);
  robot_data_.has_robot_data = false;
  robot_data_.robot_state = franka::RobotState();
  lock_data.unlock();
```
the `RobotState` constructor default to user stopped mode

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ✅Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
