### PR TITLE
Bgc.compliant.push

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -375,8 +375,6 @@ void CommunicationInterface::HandleCompliantPushReq(
   } else {
     compliant_push_stop_requested_ = true;
   }
-  new_plan_buffer_.plan = std::make_unique<PPType>();
-  new_plan_buffer_.utime = msg->utime;
 }
 
 void CommunicationInterface::HandlePlan(

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -72,7 +72,7 @@ CommunicationInterface::CommunicationInterface(const RobotParameters& params,
                  this);
   lcm_.subscribe(params_.lcm_stop_channel, &CommunicationInterface::HandlePause,
                  this);
-  lcm_.subscribe(params_.lcm_stop_channel,
+  lcm_.subscribe(params_.lcm_compliant_push_req_channel,
                  &CommunicationInterface::HandleCompliantPushReq, this);
 
   // TODO(@anyone): define this in parameters file

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -366,6 +366,7 @@ void CommunicationInterface::HandleCompliantPushReq(
     const ::lcm::ReceiveBuffer*, const std::string&,
     const robot_msgs::bool_t* msg) {
   compliant_push_requested_ = msg->data;
+  new_plan_buffer_.plan = std::make_unique<PPType>();
   new_plan_buffer_.utime = msg->utime;
 }
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -372,8 +372,10 @@ void CommunicationInterface::HandleCompliantPushReq(
     const robot_msgs::bool_t* msg) {
   if (msg->data) {
     compliant_push_start_requested_ = true;
-  } else {
+  } else if (compliant_push_active_) {
     compliant_push_stop_requested_ = true;
+  } else {
+    log()->warn("CompliantPush not currently active but STOP requested!");
   }
 }
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -72,8 +72,8 @@ CommunicationInterface::CommunicationInterface(const RobotParameters& params,
                  this);
   lcm_.subscribe(params_.lcm_stop_channel, &CommunicationInterface::HandlePause,
                  this);
-  lcm_.subscribe(params_.lcm_stop_channel, &CommunicationInterface::HandleCompliantPushReq,
-                 this);
+  lcm_.subscribe(params_.lcm_stop_channel,
+                 &CommunicationInterface::HandleCompliantPushReq, this);
 
   // TODO(@anyone): define this in parameters file
   lcm_driver_status_channel_ = params_.robot_name + "_DRIVER_STATUS";
@@ -366,6 +366,7 @@ void CommunicationInterface::HandleCompliantPushReq(
     const ::lcm::ReceiveBuffer*, const std::string&,
     const robot_msgs::bool_t* msg) {
   compliant_push_requested_ = msg->data;
+  new_plan_buffer_.utime = msg->utime;
 }
 
 void CommunicationInterface::HandlePlan(

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -72,12 +72,15 @@ CommunicationInterface::CommunicationInterface(const RobotParameters& params,
                  this);
   lcm_.subscribe(params_.lcm_stop_channel, &CommunicationInterface::HandlePause,
                  this);
+  lcm_.subscribe(params_.lcm_stop_channel, &CommunicationInterface::HandleCompliantPushReq,
+                 this);
 
   // TODO(@anyone): define this in parameters file
   lcm_driver_status_channel_ = params_.robot_name + "_DRIVER_STATUS";
   // TODO(@anyone): remove these channels and combine with robot status channel
   lcm_pause_status_channel_ = params_.robot_name + "_PAUSE_STATUS";
   lcm_user_stop_channel_ = params_.robot_name + "_USER_STOPPED";
+  lcm_compliant_push_req_channel_ = params_.robot_name + "_COMPLIANT_PUSH_REQ";
   lcm_brakes_locked_channel_ = params_.robot_name + "_BRAKES_LOCKED";
   lcm_sim_driver_event_trigger_channel_ =
       params_.robot_name + "_SIM_EVENT_TRIGGER";
@@ -357,6 +360,12 @@ bool CommunicationInterface::CanReceiveCommands(
       dexai::log()->error("CanReceiveCommands: Mode unknown!");
       return false;
   }
+}
+
+void CommunicationInterface::HandleCompliantPushReq(
+    const ::lcm::ReceiveBuffer*, const std::string&,
+    const robot_msgs::bool_t* msg) {
+  compliant_push_requested_ = msg->data;
 }
 
 void CommunicationInterface::HandlePlan(

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -59,6 +59,7 @@
 
 #include "franka/robot_state.h"         // for RobotState
 #include "lcmtypes/robot_spline_t.hpp"  // for robot_spline_t
+#include "robot_msgs/bool_t.hpp"     // for pause_cmd
 #include "robot_msgs/pause_cmd.hpp"     // for pause_cmd
 #include "utils/robot_parameters.h"     // for RobotParameters
 
@@ -98,6 +99,9 @@ class CommunicationInterface {
   void ClearSimControlExceptionTrigger() {
     sim_control_exception_triggered_ = false;
   }
+
+  bool CompliantPushFwdRequested() const { return compliant_push_requested_; }
+  void ClearCompliantPushFwdRequest() { compliant_push_requested_ = false; }
 
   bool CancelPlanRequested() const { return cancel_plan_requested_; }
   void ClearCancelPlanRequest() { cancel_plan_requested_ = false; }
@@ -167,6 +171,8 @@ class CommunicationInterface {
                   const lcmtypes::robot_spline_t* robot_spline);
   void HandlePause(const ::lcm::ReceiveBuffer*, const std::string&,
                    const robot_msgs::pause_cmd* pause_cmd_msg);
+  void HandleCompliantPushReq(const ::lcm::ReceiveBuffer*, const std::string&,
+                              const robot_msgs::bool_t* msg);
 
   /// Handler for control exception and u-stop triggers for simulated driver so
   /// we can test full spectrum of driver states.
@@ -179,6 +185,7 @@ class CommunicationInterface {
   std::atomic_bool running_ {false};
   std::atomic<bool> sim_control_exception_triggered_ {false};
   std::atomic<bool> cancel_plan_requested_ {false};
+  std::atomic<bool> compliant_push_requested_ {false};
   std::atomic<bool> is_sim_ {false};
 
   ::lcm::LCM lcm_;
@@ -201,6 +208,7 @@ class CommunicationInterface {
   std::string lcm_driver_status_channel_;
   std::string lcm_pause_status_channel_;
   std::string lcm_user_stop_channel_;
+  std::string lcm_compliant_push_req_channel_;
   std::string lcm_brakes_locked_channel_;
   std::string lcm_sim_driver_event_trigger_channel_;
 

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -46,22 +46,22 @@
 /// If a pause message is received, it will set the pause status to true and
 /// keep track of what source paused it.
 
-#include <drake/common/trajectories/piecewise_polynomial.h>  // for Piecewis...
+#include <drake/common/trajectories/piecewise_polynomial.h>
 
 #include <memory>
-#include <mutex>  // for mutex
+#include <mutex>
 #include <set>
 #include <string>
-#include <thread>  // for thread
+#include <thread>
 #include <tuple>
 
-#include <lcm/lcm-cpp.hpp>  // for lcm
+#include <lcm/lcm-cpp.hpp>
 
-#include "franka/robot_state.h"         // for RobotState
-#include "lcmtypes/robot_spline_t.hpp"  // for robot_spline_t
-#include "robot_msgs/bool_t.hpp"     // for pause_cmd
-#include "robot_msgs/pause_cmd.hpp"     // for pause_cmd
-#include "utils/robot_parameters.h"     // for RobotParameters
+#include "franka/robot_state.h"
+#include "lcmtypes/robot_spline_t.hpp"
+#include "robot_msgs/bool_t.hpp"
+#include "robot_msgs/pause_cmd.hpp"
+#include "utils/robot_parameters.h"
 
 using drake::trajectories::PiecewisePolynomial;
 typedef PiecewisePolynomial<double> PPType;
@@ -101,7 +101,7 @@ class CommunicationInterface {
   }
 
   bool CompliantPushFwdRequested() const { return compliant_push_requested_; }
-  void ClearCompliantPushFwdRequest() { compliant_push_requested_ = false; }
+  void ClearCompliantPushRequest() { compliant_push_requested_ = false; }
 
   bool CancelPlanRequested() const { return cancel_plan_requested_; }
   void ClearCancelPlanRequest() { cancel_plan_requested_ = false; }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -934,9 +934,8 @@ franka::Torques FrankaPlanRunner::ImpedanceControlCallback(
 
   // 7x7 * 7x1
   tau_joint_centering << (jc_spring + jc_damping) * k_jc_ramp_;
-  tau_joint_centering =
-      tau_joint_centering.cwiseMin(torque_limits).cwiseMax(-torque_limits);
 
+  // linear ramp up from 0 to 1 on start
   k_jc_ramp_ = k_jc_ramp_ * (1 - filter_gain_) + filter_gain_;
 
   tau_d << tau_task + coriolis + tau_joint_centering;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -416,6 +416,7 @@ int FrankaPlanRunner::RunFranka() {
           return ret_torques;
         };
         robot_->control(impedance_control_callback);
+        comm_interface_->ClearCompliantPushFwdRequest();
         comm_interface_->PublishPlanComplete(plan_utime_, true /* = success */);
       }
       continue;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -452,9 +452,14 @@ int FrankaPlanRunner::RunFranka() {
             return ret_torques;
           }
 
-          log()->info("norm: {}\tcounter: {}", joint_vel.norm(),
-                      stopped_debounce_counter);
+          // log()->info("norm: {}\tcounter: {}", joint_vel.norm(),
+          //             stopped_debounce_counter);
 
+          const auto end_time {std::chrono::high_resolution_clock::now()};
+          const auto time_elapsed_us =
+              std::chrono::duration_cast<std::chrono::microseconds>(
+                  end_time - start_time);
+          log()->info("{} us", time_elapsed_us.count());
           return ret_torques;
         };
         robot_->control(impedance_control_callback);

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -299,8 +299,8 @@ int FrankaPlanRunner::RunFranka() {
                  && comm_interface_->CompliantPushFwdRequested()) {
         std::tie(std::ignore, plan_utime_) = comm_interface_->PopNewPlan();
         // Compliance parameters
-        static const Eigen::Vector3d translational_stiffness {300.0, 300.0, 300.0};
-        static const Eigen::Vector3d rotational_stiffness {30.0, 30.0, 30.0};
+        static const Eigen::Vector3d translational_stiffness {100.0, 100.0, 300.0};
+        static const Eigen::Vector3d rotational_stiffness {10.0, 10.0, 50.0};
 
         static const Eigen::Vector3d translational_stiffness_sqrt {translational_stiffness.array().sqrt()};
         static const Eigen::Vector3d rotational_stiffness_sqrt {rotational_stiffness.array().sqrt()};
@@ -365,7 +365,7 @@ int FrankaPlanRunner::RunFranka() {
         //             joint_limits_.col(1).transpose(),
         //             q_center.transpose(), q_half_range.transpose());
 
-        const double k_centering {1.0};
+        const double k_centering {5.0};
 
         const double stopped_max_vel_norm {0.002};
         const int debounce_counter_max {30};

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -365,7 +365,7 @@ int FrankaPlanRunner::RunFranka() {
                     joint_limits_.col(1).transpose(),
                     q_center.transpose(), q_half_range.transpose());
 
-        const double k_centering {5.0};
+        const double k_centering {10.0};
 
         const double stopped_max_vel_norm {0.002};
         const int debounce_counter_max {30};

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -1048,10 +1048,10 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
     Eigen::VectorXd dq_abs {
         utils::v_to_e(utils::ArrayToVector(cannonical_robot_state.dq))
             .cwiseAbs()};
-    dexai::log()->warn(
-        "JointPositionCallback: plan {} overtime, "
-        "franka_t: {:.3f}, max joint err: {:.4f}, speed norm: {:.5f}",
-        plan_utime_, franka_time_, max_joint_err, dq_abs.norm());
+    // dexai::log()->warn(
+    //     "JointPositionCallback: plan {} overtime, "
+    //     "franka_t: {:.3f}, max joint err: {:.4f}, speed norm: {:.5f}",
+    //     plan_utime_, franka_time_, max_joint_err, dq_abs.norm());
     // check convergence, return finished if two conditions are met
     if (max_joint_err <= CONV_ANGLE_THRESHOLD
         && (dq_abs.array() <= CONV_SPEED_THRESHOLD.array()).all()
@@ -1109,10 +1109,10 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
       plan_utime_ = -1;  // reset plan to -1
       return franka::MotionFinished(output_to_franka);
     }
-    dexai::log()->warn(
-        "JointPositionCallback: plan {} overtime, diverged or still moving, "
-        "within allowed grace period",
-        plan_utime_);
+    // dexai::log()->warn(
+    //     "JointPositionCallback: plan {} overtime, diverged or still moving, "
+    //     "within allowed grace period",
+    //     plan_utime_);
   }
   return output_to_franka;
 }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -336,11 +336,11 @@ int FrankaPlanRunner::RunFranka() {
           dexai::log()->error(
               "RunFranka: exception in impedance control callback: {}",
               ce.what());
+          comm_interface_->SetCompliantPushActive(false);
           if (!RecoverFromControlException()) {  // plan_ is released/reset
             dexai::log()->critical(
                 "RunFranka: RecoverFromControlException failed");
             comm_interface_->PublishDriverStatus(false, ce.what());
-            comm_interface_->SetCompliantPushActive(false);
             return 1;
           }
         }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -478,7 +478,10 @@ int FrankaPlanRunner::RunFranka() {
           // 7x1
           Eigen::Matrix<double, 7, 1> q_diff_from_center {q - q_center};
           q_diff_from_center = q_diff_from_center.array() / q_half_range.array();
-          q_diff_from_center = q_diff_from_center.array().pow(9);
+          
+          const Eigen::Matrix<double, 7, 1> sgn_q_diff {q_diff_from_center.array() / q_diff_from_center.array().abs()};
+          const Eigen::Matrix<double, 7, 1> error_exp {2 * q_diff_from_center.array().pow(10).exp()};
+          const Eigen::Matrix<double, 7, 1> q_error {sgn_q_diff.array() * error_exp.array()};
 
           const auto cart_vel {jacobian * dq};
 
@@ -508,7 +511,7 @@ int FrankaPlanRunner::RunFranka() {
 
           // 7x7 * 7x1
           tau_joint_centering
-              << null_space_normalized_working_copy * (q_diff_from_center * (-k_centering) + dq * (-2 * sqrt(k_centering)) );
+              << null_space_normalized_working_copy * (q_error * (-k_centering) + dq * (-2 * sqrt(k_centering)) );
           tau_joint_centering = tau_joint_centering.cwiseMin(torque_limits).cwiseMax(-torque_limits);
 
           tau_d << tau_task + coriolis + tau_joint_centering;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -299,7 +299,7 @@ int FrankaPlanRunner::RunFranka() {
         continue;
       } else if (status_ == RobotStatus::Running
                  && comm_interface_->CompliantPushStartRequested()) {
-        std::tie(std::ignore, plan_utime_) = comm_interface_->PopNewPlan();
+        std::tie(plan_, plan_utime_) = comm_interface_->PopNewPlan();
 
         model_ = std::make_unique<franka::Model>(robot_->loadModel());
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -418,8 +418,8 @@ int FrankaPlanRunner::RunFranka() {
         robot_->control(impedance_control_callback);
         comm_interface_->ClearCompliantPushFwdRequest();
         comm_interface_->PublishPlanComplete(plan_utime_, true /* = success */);
+        continue;
       }
-      continue;
       // no new plan available in the buffer or robot isn't running
       if (comm_interface_->CancelPlanRequested()) {
         log()->debug(

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -301,11 +301,11 @@ int FrankaPlanRunner::RunFranka() {
         continue;
       } else if (status_ == RobotStatus::Running
                  && comm_interface_->CompliantPushStartRequested()) {
-        franka::RobotState initial_state = robot_->readOnce();
+        franka::RobotState initial_state {robot_->readOnce()};
 
         // THIS is equivalent of "plan" AKA desired direction of push.
         // TODO(@syler/@gavin): make this a parameter passed in push request
-        auto desired_move {Eigen::Vector3d(0, 0, 0.050)};
+        static const auto desired_move {Eigen::Vector3d(0, 0, 0.050)};
 
         SetCompliantPushParameters(initial_state, desired_move);
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -342,6 +342,10 @@ int FrankaPlanRunner::RunFranka() {
 
         const Eigen::Matrix<double, 7, 1> q_center =
             0.5 * (joint_limits_.col(0) + joint_limits_.col(1));
+        log()->info("Limits: \n\t{}\n\t{}\nCenter:\n\t{}",
+          joint_limits_.col(0).transpose(),
+          joint_limits_.col(1).transpose(),
+          q_center.transpose());
 
         const double k_centering {0.001};
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -489,11 +489,12 @@ int FrankaPlanRunner::RunFranka() {
 
           // 7x1
           Eigen::Matrix<double, 7, 1> q_diff_from_center {q - q_center};
-          q_diff_from_center = q_diff_from_center.array() / q_half_range.array();
-          
-          const Eigen::Matrix<double, 7, 1> sgn_q_diff {q_diff_from_center.array() / q_diff_from_center.array().abs()};
-          const Eigen::Matrix<double, 7, 1> error_exp {2 * q_diff_from_center.array().pow(10).exp()};
-          const Eigen::Matrix<double, 7, 1> q_error {sgn_q_diff.array() * (error_exp.array()-1)};
+          // q_diff_from_center = q_diff_from_center.array() / q_half_range.array();
+
+          // const Eigen::Matrix<double, 7, 1> sgn_q_diff {q_diff_from_center.array() / q_diff_from_center.array().abs()};
+          // const Eigen::Matrix<double, 7, 1> error_exp {2 * q_diff_from_center.array().pow(10).exp()};
+          // const Eigen::Matrix<double, 7, 1> q_error {sgn_q_diff.array() * (error_exp.array()-1)};
+	  // log()->info("qdiff: {}\tqerror: {}", q_diff_from_center.transpose(), q_error.transpose());
 
           const auto cart_vel {jacobian * dq};
 
@@ -523,7 +524,7 @@ int FrankaPlanRunner::RunFranka() {
 
           // 7x7 * 7x1
           tau_joint_centering
-              << null_space_normalized_working_copy * (q_error * (-k_centering) + dq * (-2 * sqrt(k_centering)) );
+              << null_space_normalized_working_copy * (q_diff_from_center * (-k_centering) + dq * (-2 * sqrt(k_centering)) );
           tau_joint_centering = tau_joint_centering.cwiseMin(torque_limits).cwiseMax(-torque_limits);
 
           tau_d << tau_task + coriolis + tau_joint_centering;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -360,10 +360,10 @@ int FrankaPlanRunner::RunFranka() {
         const Eigen::Matrix<double, 7, 1> q_half_range {
             0.5 * (joint_limits_.col(1)-joint_limits_.col(0))};
 
-        // log()->info("Limits: \n\t{}\n\t{}\nCenter:\n\t{}\nRange/2:\n\t:{}",
-        //             joint_limits_.col(0).transpose(),
-        //             joint_limits_.col(1).transpose(),
-        //             q_center.transpose(), q_half_range.transpose());
+        log()->info("Limits: \n\t{}\n\t{}\nCenter:\n\t{}\nRange/2:\n\t:{}",
+                    joint_limits_.col(0).transpose(),
+                    joint_limits_.col(1).transpose(),
+                    q_center.transpose(), q_half_range.transpose());
 
         const double k_centering {5.0};
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -340,7 +340,7 @@ int FrankaPlanRunner::RunFranka() {
             {{100.0, 100.0, 100.0, 100.0, 100.0, 100.0}},
             {{100.0, 100.0, 100.0, 100.0, 100.0, 100.0}});
 
-        const double stopped_max_vel_norm {0.1};
+        const double stopped_max_vel_norm {0.01};
         int stopped_debounce_counter {};
 
         // define callback for the torque control loop
@@ -408,7 +408,7 @@ int FrankaPlanRunner::RunFranka() {
             stopped_debounce_counter = 0;
           }
 
-          if (stopped_debounce_counter > 20) {
+          if (stopped_debounce_counter > 30) {
             ret_torques.motion_finished = true;
             return ret_torques;
           }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -897,24 +897,6 @@ franka::Torques FrankaPlanRunner::ImpedanceControlCallback(
   // Transform to base frame
   error.tail(3) << -transform.linear() * error.tail(3);
 
-  // // 7x7
-  // const auto inertia_inv {inertia.inverse()};
-
-  // // (6x7 * 7x7 * 7x6)^-1 = 6x6
-  // const auto inertia_op_space {
-  //     (jacobian * inertia_inv * jacobian.transpose()).inverse()};
-
-  // // 7x7 * 7x6 * 6x6 = 7x6
-  // const auto dyn_J_inv {inertia_inv * jacobian.transpose()
-  //                       * inertia_op_space};
-
-  // // 7x6 * 6x7 = 7x7
-  // const Eigen::Matrix<double, 7, 7> null_space {
-  //     Eigen::Matrix<double, 7, 7>::Identity() - dyn_J_inv *
-  //     jacobian};
-  // const Eigen::Matrix<double, 7, 7> null_space_normalized_ {
-  //     null_space.array() / null_space.norm()};
-
   // 7x1
   Eigen::Matrix<double, 7, 1> q_diff_from_center {q - q_center_};
   Eigen::Matrix<double, 7, 1> q_diff_from_center_norm =
@@ -933,13 +915,6 @@ franka::Torques FrankaPlanRunner::ImpedanceControlCallback(
                                                           10.0, 10.0, 10.0};
   Eigen::Map<const Eigen::Matrix<double, 6, 1>> wrench_limits {
       wrench_limits_array.data()};
-
-  // Eigen::Matrix<double, 6, 1> task_wrench {(-stiffness * error -
-  // damping * (cart_vel))};
-  // // log()->info("task_wrench: {}", task_wrench.transpose());
-  // // task_wrench =
-  // task_wrench.cwiseMin(wrench_limits).cwiseMax(-wrench_limits);
-  // // log()->info("task_wrench*: {}", task_wrench.transpose());
 
   Eigen::Matrix<double, 6, 1> task_wrench {
       (-stiffness_ * error - damping_ * (cart_vel))};

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -413,6 +413,8 @@ int FrankaPlanRunner::RunFranka() {
             return ret_torques;
           }
 
+          log()->info("norm: {}\tcounter: {}", joint_vel.norm(), stopped_debounce_counter);
+
           return ret_torques;
         };
         robot_->control(impedance_control_callback);

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -263,7 +263,8 @@ int FrankaPlanRunner::RunFranka() {
         t_last_main_loop_log_ = t_now;
       }
       // prevent the plan from being started if robot is not running...
-      if (status_ == RobotStatus::Running && comm_interface_->HasNewPlan()) {
+      if (status_ == RobotStatus::Running && comm_interface_->HasNewPlan()
+          && !comm_interface_->CompliantPushFwdRequested()) {
         dexai::log()->info(
             "RunFranka: found a new plan in buffer, attaching callback...");
         status_has_changed = true;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -492,6 +492,7 @@ int FrankaPlanRunner::RunFranka() {
           Eigen::Matrix<double, 7, 1> q_diff_from_center {q - q_center};
           Eigen::Matrix<double, 7, 1> q_diff_from_center_norm = q_diff_from_center.array() / q_half_range.array();
 
+          // https://www.desmos.com/calculator/8glrxv3bh4
           const Eigen::Matrix<double, 7, 1> sgn_q_diff {q_diff_from_center_norm.array() / q_diff_from_center_norm.array().abs()};
           const Eigen::Matrix<double, 7, 1> error_exp {(q_diff_from_center_norm + sgn_q_diff * 0.02).array().pow(50).exp()};
           const Eigen::Matrix<double, 7, 1> q_error {sgn_q_diff.array() * (error_exp.array()-1)};

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -933,8 +933,7 @@ franka::Torques FrankaPlanRunner::ImpedanceControlCallback(
   const auto jc_damping {dq * (-2 * sqrt(k_centering_))};
 
   // 7x7 * 7x1
-  tau_joint_centering << /* _ * */ (jc_spring + jc_damping);
-  tau_joint_centering = tau_joint_centering * k_jc_ramp_;
+  tau_joint_centering << (jc_spring + jc_damping) * k_jc_ramp_;
   tau_joint_centering =
       tau_joint_centering.cwiseMin(torque_limits).cwiseMax(-torque_limits);
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -321,7 +321,7 @@ int FrankaPlanRunner::RunFranka() {
             Eigen::Matrix4d::Map(initial_state.O_T_EE.data()));
 
         Eigen::Affine3d desired_xform {initial_transform};
-        desired_xform.translate(Eigen::Vector3d(0, 0, 0.075));
+        desired_xform.translate(Eigen::Vector3d(0, 0, 0.055));
 
         const auto initial_trans {initial_transform.translation()};
         std::cerr << initial_trans.transpose() << std::endl;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -291,6 +291,8 @@ int FrankaPlanRunner::RunFranka() {
           }
         }
         continue;
+      } else if (status_ == RobotStatus::Running && comm_interface_->CompliantPushFwdRequested()) {
+        // robot_->control()
       }
       // no new plan available in the buffer or robot isn't running
       if (comm_interface_->CancelPlanRequested()) {

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -493,7 +493,7 @@ int FrankaPlanRunner::RunFranka() {
           
           const Eigen::Matrix<double, 7, 1> sgn_q_diff {q_diff_from_center.array() / q_diff_from_center.array().abs()};
           const Eigen::Matrix<double, 7, 1> error_exp {2 * q_diff_from_center.array().pow(10).exp()};
-          const Eigen::Matrix<double, 7, 1> q_error {sgn_q_diff.array() * error_exp.array()};
+          const Eigen::Matrix<double, 7, 1> q_error {sgn_q_diff.array() * (error_exp.array()-1)};
 
           const auto cart_vel {jacobian * dq};
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -120,7 +120,6 @@ FrankaPlanRunner::FrankaPlanRunner(const RobotParameters& params)
   }
 
   log()->warn("Collision Safety {}", safety_off_ ? "OFF" : "ON");
-
   if (safety_off_) {
     upper_torque_threshold_ = kHighTorqueThreshold;
     upper_force_threshold_ = kHighForceThreshold;
@@ -163,6 +162,9 @@ int FrankaPlanRunner::RunFranka() {
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         continue;
       }
+
+      // robot model for impedance control calculations
+      model_ = std::make_unique<franka::Model>(robot_->loadModel());
 
       auto current_mode {GetRobotMode()};
       if (auto t_now {std::chrono::steady_clock::now()};
@@ -299,8 +301,6 @@ int FrankaPlanRunner::RunFranka() {
         continue;
       } else if (status_ == RobotStatus::Running
                  && comm_interface_->CompliantPushStartRequested()) {
-        model_ = std::make_unique<franka::Model>(robot_->loadModel());
-
         franka::RobotState initial_state = robot_->readOnce();
 
         // THIS is equivalent of "plan" AKA desired direction of push.

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -359,6 +359,8 @@ int FrankaPlanRunner::RunFranka() {
             return 1;
           }
         }
+        plan_.release();
+        plan_utime_ = -1;  // reset plan utime to -1
         comm_interface_->SetCompliantPushActive(false);
         comm_interface_->ClearCompliantPushStartRequest();
         continue;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -323,6 +323,7 @@ int FrankaPlanRunner::RunFranka() {
 
         // define callback for the torque control loop
         try {
+          log()->info("CompliantPush START requested.");
           comm_interface_->SetCompliantPushActive(true);
           comm_interface_->ClearCompliantPushStartRequest();
           robot_->control(std::bind(&FrankaPlanRunner::ImpedanceControlCallback,
@@ -992,6 +993,7 @@ franka::Torques FrankaPlanRunner::ImpedanceControlCallback(
 
   franka::Torques ret_torques {tau_d_array};
   if (comm_interface_->CompliantPushStopRequested()) {
+    log()->info("CompliantPush STOP requested.");
     comm_interface_->ClearCompliantPushStopRequest();
     comm_interface_->SetCompliantPushActive(false);
     ret_torques.motion_finished = true;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -347,7 +347,7 @@ int FrankaPlanRunner::RunFranka() {
           joint_limits_.col(1).transpose(),
           q_center.transpose());
 
-        const double k_centering {0.001};
+        const double k_centering {0.01};
 
         const double stopped_max_vel_norm {0.01};
         int stopped_debounce_counter {};

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -294,6 +294,7 @@ int FrankaPlanRunner::RunFranka() {
         continue;
       } else if (status_ == RobotStatus::Running
                  && comm_interface_->CompliantPushFwdRequested()) {
+        std::tie(std::ignore, plan_utime_) = comm_interface_->PopNewPlan();
         // Compliance parameters
         const double translational_stiffness {300.0};
         const double rotational_stiffness {10.0};
@@ -413,7 +414,10 @@ int FrankaPlanRunner::RunFranka() {
 
           return ret_torques;
         };
+        robot_->control(impedance_control_callback);
+        comm_interface_->PublishPlanComplete(plan_utime_, true /* = success */);
       }
+      continue;
       // no new plan available in the buffer or robot isn't running
       if (comm_interface_->CancelPlanRequested()) {
         log()->debug(

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -618,7 +618,7 @@ int FrankaPlanRunner::RunFranka() {
             return 1;
           }
         }
-        comm_interface_->ClearCompliantPushFwdRequest();
+        comm_interface_->ClearCompliantPushRequest();
         continue;
       }
       // no new plan available in the buffer or robot isn't running

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -263,6 +263,9 @@ class FrankaPlanRunner {
   const std::array<double, 6> kMediumForceThreshold {40.0, 40.0, 40.0,
                                                      50.0, 50.0, 50.0};
 
+  const std::array<double, 7> kJointTorqueLimits {87.0, 87.0, 87.0, 87.0,
+                                                  12.0, 12.0, 12.0};
+
   std::array<double, 7> upper_torque_threshold_;
   std::array<double, 6> upper_force_threshold_;
 

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -333,8 +333,8 @@ class FrankaPlanRunner {
 
   std::unique_ptr<franka::Model> model_ {};
 
-  Eigen::Vector3d position_d_;
-  Eigen::Quaterniond orientation_d_;
+  Eigen::Vector3d desired_position_;
+  Eigen::Quaterniond desired_orientation_;
 
 };  // FrankaPlanRunner
 

--- a/src/utils/robot_parameters.cc
+++ b/src/utils/robot_parameters.cc
@@ -138,6 +138,7 @@ bool RobotParameters::GenerateParametersBasedOnRobotName(
   lcm_plan_complete_channel = new_robot_name + "_PLAN_COMPLETE";
   lcm_stop_channel = new_robot_name + "_STOP";
   lcm_user_stop_channel = new_robot_name + "_USER_STOPPED";
+  lcm_compliant_push_req_channel = new_robot_name + "_COMPLIANT_PUSH_REQ";
 
   return true;
 }
@@ -257,7 +258,7 @@ RobotParameters loadYamlParameters(
     p.lcm_plan_complete_channel = p.robot_name + "_PLAN_COMPLETE";
     p.lcm_stop_channel = p.robot_name + "_STOP";
     p.lcm_user_stop_channel = p.robot_name + "_USER_STOPPED";
-
+    p.lcm_compliant_push_req_channel = p.robot_name + "_COMPLIANT_PUSH_REQ";
     get_yaml_val_or_die(param, "lcm_url", p.lcm_url, yaml_full_path, verbose,
                         exit_code);
     get_yaml_val_or_die(param, "robot_ip", p.robot_ip, yaml_full_path, verbose,

--- a/src/utils/robot_parameters.h
+++ b/src/utils/robot_parameters.h
@@ -188,6 +188,7 @@ class RobotParameters {
   std::string lcm_plan_complete_channel;
   std::string lcm_stop_channel;
   std::string lcm_user_stop_channel;
+  std::string lcm_compliant_push_req_channel;
 
   std::string lcm_url;
   std::string robot_ip;


### PR DESCRIPTION
### Background
Add a compliant push that uses a cartesian impedance controller to push along the z-axis in the end effector frame

### What's new
- ✅ see above

### Related work
- ❌ https://github.com/DexaiRobotics/dig/pull/703

### TODOs / Nice-To-Haves
- ❌ Needs sim handler for compliant push start and stop
- ❌ Needs  flag based on envvar/params to disable compliant push and "fake it" until we can verify that torque control works on all robots

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
