### PR TITLE
Model.init.fix

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -232,6 +232,10 @@ int FrankaPlanRunner::RunFranka() {
 
   // robot model for impedance control calculations
   model_ = std::make_unique<franka::Model>(robot_->loadModel());
+  // WARNING: attempting to load model before successful connection established
+  // (with robot user stopped) and then exiting the program caused Franka
+  // controller server to experience an unrecoverable error requiring a system
+  // restart.
 
   while (true) {  // main control loop
     // make sure robot is not user-stopped before doing anything else

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -190,17 +190,13 @@ int FrankaPlanRunner::RunFranka() {
             fmt::format("robot cannot receive commands in mode: {} at startup",
                         utils::RobotModeToString(current_mode))};
         comm_interface_->PublishDriverStatus(false, err_msg);
+        if (current_mode == franka::RobotMode::kUserStopped) {
+          comm_interface_->PublishBoolToChannel(
+              utils::get_current_utime(),
+              comm_interface_->GetUserStopChannelName(), true);
+        }
         if (t_now - t_last_main_loop_log_ >= std::chrono::seconds(1)) {
           dexai::log()->error("RunFranka: {}", err_msg);
-          t_last_main_loop_log_ = t_now;
-        }
-      } else if (current_mode == franka::RobotMode::kUserStopped) {
-        comm_interface_->PublishBoolToChannel(
-            utils::get_current_utime(),
-            comm_interface_->GetUserStopChannelName(), true);
-        if (t_now - t_last_main_loop_log_ >= std::chrono::seconds(1)) {
-          dexai::log()->error(
-              "RunFranka: robot is in User-Stopped mode at startup");
           t_last_main_loop_log_ = t_now;
         }
       } else {  // if we got this far, we are talking to Franka and it is happy

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -154,8 +154,6 @@ int FrankaPlanRunner::RunFranka() {
     do {  // do-while(!connection_established) loop, execute once first
       try {
         robot_ = std::make_unique<franka::Robot>(ip_addr_);
-        dexai::log()->info("RunFranka: connected to franka server, version {}",
-                           robot_->serverVersion());
       } catch (franka::Exception const& e) {
         // probably something wrong with networking
         auto err_msg {fmt::format("Franka connection error: {}", e.what())};
@@ -208,6 +206,9 @@ int FrankaPlanRunner::RunFranka() {
       }
     } while (!connection_established);
   }
+
+  dexai::log()->info("RunFranka: connected to franka server, version {}",
+                     robot_->serverVersion());
 
   try {  // initilization
     dexai::log()->info("RunFranka: setting default behavior...");

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -165,9 +165,6 @@ int FrankaPlanRunner::RunFranka() {
         continue;
       }
 
-      // robot model for impedance control calculations
-      model_ = std::make_unique<franka::Model>(robot_->loadModel());
-
       auto current_mode {GetRobotMode()};
       if (auto t_now {std::chrono::steady_clock::now()};
           current_mode == franka::RobotMode::kReflex) {
@@ -236,6 +233,9 @@ int FrankaPlanRunner::RunFranka() {
 
   status_ = RobotStatus::Running;  // init done, define robot as running
   bool status_has_changed {true};
+
+  // robot model for impedance control calculations
+  model_ = std::make_unique<franka::Model>(robot_->loadModel());
 
   while (true) {  // main control loop
     // make sure robot is not user-stopped before doing anything else


### PR DESCRIPTION
### Background

- Fixes unrecoverable server error occurring if robot user stopped on startup and driver killed
- Publish u-stop status in loop before connection to robot established

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: tried restarting driver on u-stopped robot, verified successful connection

### Quality
3. ✅New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
