### PR TITLE
Published both locked  and user stopped status during startup loop

### DIFF
--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -165,6 +165,9 @@ class CommunicationInterface {
                              int8_t data, std::string_view source = "");
 
   std::string GetUserStopChannelName() { return lcm_user_stop_channel_; }
+  std::string GetBrakesLockedChannelName() {
+    return lcm_brakes_locked_channel_;
+  }
 
   /// check if robot is in a mode that can receive commands, i.e. not user
   /// stopped or error recovery

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -183,23 +183,22 @@ int FrankaPlanRunner::RunFranka() {
               "error recovery for Reflex mode: {}.",
               ce.what());
         }
-      } else if (current_mode == franka::RobotMode::kUserStopped) {
-        auto err_msg {
-            fmt::format("robot cannot receive commands in mode: {} at startup",
-                        utils::RobotModeToString(current_mode))};
-        comm_interface_->PublishDriverStatus(false, err_msg);
-        comm_interface_->PublishBoolToChannel(
-            utils::get_current_utime(),
-            comm_interface_->GetUserStopChannelName(), true);
-        if (t_now - t_last_main_loop_log_ >= std::chrono::seconds(1)) {
-          dexai::log()->error("RunFranka: {}", err_msg);
-          t_last_main_loop_log_ = t_now;
-        }
       } else if (current_mode != franka::RobotMode::kIdle) {  // any other mode
         auto err_msg {
             fmt::format("robot cannot receive commands in mode: {} at startup",
                         utils::RobotModeToString(current_mode))};
         comm_interface_->PublishDriverStatus(false, err_msg);
+
+        // publish if robot is user stopped or locked on startup
+        comm_interface_->PublishBoolToChannel(
+            utils::get_current_utime(),
+            comm_interface_->GetUserStopChannelName(),
+            current_mode == franka::RobotMode::kUserStopped);
+        comm_interface_->PublishBoolToChannel(
+            utils::get_current_utime(),
+            comm_interface_->GetBrakesLockedChannelName(),
+            current_mode == franka::RobotMode::kOther);
+
         if (t_now - t_last_main_loop_log_ >= std::chrono::seconds(1)) {
           dexai::log()->error("RunFranka: {}", err_msg);
           t_last_main_loop_log_ = t_now;


### PR DESCRIPTION
### Background

- Published both locked and user stopped status during startup loop

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: tested publishing of both channels if robot is stuck in startup loop

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
