### PR TITLE
Execute plan until contact

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -487,17 +487,7 @@ void CommunicationInterface::HandlePlan(
     }
 
   } else {
-    // Piecewise pose
-    auto X_EEcurrent_EEdesired {
-        utils::ToRigidTransform(robot_spline->cartesian_goal)};
-
-    std::vector<double> times_vec {0, 10.0};
-    auto cartesian_plan {PosePoly::MakeCubicLinearWithEndLinearVelocity(
-        times_vec,
-        {drake::math::RigidTransformd::Identity(), X_EEcurrent_EEdesired})};
-
-    new_plan_buffer_.cartesian_plan =
-        std::make_unique<PosePoly>(cartesian_plan);
+    // Cartesian goal command. Not implemented yet. Ignore for now
   }
   lock.unlock();
   dexai::log()->info(

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -456,18 +456,17 @@ void CommunicationInterface::HandlePlan(
 
     // Start position == goal position check
     // TODO(@anyone): change to append initial position and respline here
-    Eigen::VectorXd commanded_start =
-        piecewise_polynomial.value(piecewise_polynomial.start_time());
+    Eigen::VectorXd commanded_start {
+        piecewise_polynomial.value(piecewise_polynomial.start_time())};
 
-    auto q = this->GetRobotState().q;
     // TODO(@anyone): move this check to franka plan runner
-    Eigen::VectorXd q_eigen = utils::v_to_e(utils::ArrayToVector(q));
+    Eigen::VectorXd q_eigen {utils::v_to_e(utils::ArrayToVector(this->GetRobotState().q))};
 
-    auto max_angular_distance =
-        utils::max_angular_distance(commanded_start, q_eigen);
+    double max_angular_distance {
+        utils::max_angular_distance(commanded_start, q_eigen)};
     if (max_angular_distance > params_.kMediumJointDistance) {
       // discard the plan if we are too far away from current robot start
-      Eigen::VectorXd joint_delta = q_eigen - commanded_start;
+      auto joint_delta {q_eigen - commanded_start};
       dexai::log()->error(
           "CommInterface:HandlePlan: "
           "discarding plan {}, mismatched start position with delta: {}.",

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -60,6 +60,7 @@
 #include <robot_msgs/bool_t.hpp>
 #include <robot_msgs/pause_cmd.hpp>
 #include <robot_msgs/robot_spline_t.hpp>
+#include <robot_msgs/plan_exec_opts_t.hpp>
 
 #include "franka/robot_state.h"
 #include "utils/robot_parameters.h"
@@ -86,6 +87,7 @@ struct PauseData {
 
 struct RobotPlanBuffer {
   int64_t utime;
+  int16_t exec_opt; 
   std::unique_ptr<PPType> plan;
   std::unique_ptr<PosePoly> cartesian_plan;
 };
@@ -147,8 +149,8 @@ class CommunicationInterface {
     new_plan_buffer_.utime = -1;
   }
 
-  std::tuple<std::unique_ptr<PPType>, int64_t> PopNewPlan();
-  std::tuple<std::unique_ptr<PosePoly>, int64_t> PopNewCartesianPlan();
+  std::tuple<std::unique_ptr<PPType>, int64_t, int16_t> PopNewPlan();
+  std::tuple<std::unique_ptr<PosePoly>, int64_t, int16_t> PopNewCartesianPlan();
 
   // TODO(@anyone): remove franka specific RobotState type and
   // replace with std::array

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -59,8 +59,8 @@
 #include <lcm/lcm-cpp.hpp>
 #include <robot_msgs/bool_t.hpp>
 #include <robot_msgs/pause_cmd.hpp>
-#include <robot_msgs/robot_spline_t.hpp>
 #include <robot_msgs/plan_exec_opts_t.hpp>
+#include <robot_msgs/robot_spline_t.hpp>
 
 #include "franka/robot_state.h"
 #include "utils/robot_parameters.h"
@@ -87,7 +87,8 @@ struct PauseData {
 
 struct RobotPlanBuffer {
   int64_t utime;
-  int16_t exec_opt; 
+  int16_t exec_opt;
+  Eigen::Vector3d contact_expected {};
   std::unique_ptr<PPType> plan;
   std::unique_ptr<PosePoly> cartesian_plan;
 };
@@ -149,7 +150,8 @@ class CommunicationInterface {
     new_plan_buffer_.utime = -1;
   }
 
-  std::tuple<std::unique_ptr<PPType>, int64_t, int16_t> PopNewPlan();
+  std::tuple<std::unique_ptr<PPType>, int64_t, int16_t, Eigen::Vector3d>
+  PopNewPlan();
   std::tuple<std::unique_ptr<PosePoly>, int64_t, int16_t> PopNewCartesianPlan();
 
   // TODO(@anyone): remove franka specific RobotState type and

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -757,7 +757,7 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
       utils::v_to_e(utils::ArrayToVector(cannonical_robot_state.q_d));
 
   if (comm_interface_->HasNewPlan()) {  // pop the new plan and set it up
-    std::tie(plan_, plan_utime_, plan_exec_opt_) =
+    std::tie(plan_, plan_utime_, plan_exec_opt_, contact_expected_) =
         comm_interface_->PopNewPlan();
     dexai::log()->info(
         "JointPositionCallback: popped new plan {} from buffer, "
@@ -860,7 +860,8 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
         robot_state.cartesian_contact.data());
     if ((cartesian_contact.head(3).array() > 0).any()) {
       comm_interface_->PublishPlanComplete(
-          plan_utime_, true, fmt::format("made contact: {}", cartesian_contact.transpose()));
+          plan_utime_, true,
+          fmt::format("made contact: {}", cartesian_contact.transpose()));
       plan_.reset();     // reset unique ptr
       plan_utime_ = -1;  // reset plan to -1
       return franka::MotionFinished(output_to_franka);

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -121,9 +121,15 @@ FrankaPlanRunner::FrankaPlanRunner(const RobotParameters& params)
 
   log()->warn("Collision Safety {}", safety_off_ ? "OFF" : "ON");
   if (safety_off_) {
+    lower_torque_threshold_ = kLowTorqueThreshold;
+    lower_force_threshold_ = kLowForceThreshold;
+
     upper_torque_threshold_ = kHighTorqueThreshold;
     upper_force_threshold_ = kHighForceThreshold;
   } else {
+    lower_torque_threshold_ = kLowTorqueThreshold;
+    lower_force_threshold_ = kLowForceThreshold;
+
     upper_torque_threshold_ = kMediumTorqueThreshold;
     upper_force_threshold_ = kMediumForceThreshold;
   }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -757,7 +757,8 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
       utils::v_to_e(utils::ArrayToVector(cannonical_robot_state.q_d));
 
   if (comm_interface_->HasNewPlan()) {  // pop the new plan and set it up
-    std::tie(plan_, plan_utime_) = comm_interface_->PopNewPlan();
+    std::tie(plan_, plan_utime_, plan_exec_opt_) =
+        comm_interface_->PopNewPlan();
     dexai::log()->info(
         "JointPositionCallback: popped new plan {} from buffer, "
         "starting initial timestep...",

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -120,16 +120,12 @@ FrankaPlanRunner::FrankaPlanRunner(const RobotParameters& params)
   }
 
   log()->warn("Collision Safety {}", safety_off_ ? "OFF" : "ON");
+  lower_torque_threshold_ = kLowTorqueThreshold;
+  lower_force_threshold_ = kLowForceThreshold;
   if (safety_off_) {
-    lower_torque_threshold_ = kLowTorqueThreshold;
-    lower_force_threshold_ = kLowForceThreshold;
-
     upper_torque_threshold_ = kHighTorqueThreshold;
     upper_force_threshold_ = kHighForceThreshold;
   } else {
-    lower_torque_threshold_ = kLowTorqueThreshold;
-    lower_force_threshold_ = kLowForceThreshold;
-
     upper_torque_threshold_ = kMediumTorqueThreshold;
     upper_force_threshold_ = kMediumForceThreshold;
   }

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -858,7 +858,11 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
   if (plan_exec_opt_ == robot_msgs::plan_exec_opts_t::MOVE_UNTIL_STOP) {
     Eigen::Map<const Eigen::Matrix<double, 6, 1>> cartesian_contact(
         robot_state.cartesian_contact.data());
-    if ((cartesian_contact.head(3).array() > 0).any()) {
+
+    const auto expected_contact_bool {contact_expected_.array() > 0};
+    const auto contact_bool {cartesian_contact.head(3).array() > 0};
+
+    if ((expected_contact_bool.cwiseProduct(contact_bool)).all()) {
       comm_interface_->PublishPlanComplete(
           plan_utime_, true,
           fmt::format("made contact: {}", cartesian_contact.transpose()));

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -855,6 +855,18 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
   }
   output_to_franka = utils::EigenToArray(output_to_franka_eigen);
 
+  if (plan_exec_opt_ == robot_msgs::plan_exec_opts_t::MOVE_UNTIL_STOP) {
+    Eigen::Map<const Eigen::Matrix<double, 6, 1>> cartesian_contact(
+        robot_state.cartesian_contact.data());
+    if ((cartesian_contact.head(3).array() > 0).any()) {
+      comm_interface_->PublishPlanComplete(
+          plan_utime_, true, fmt::format("made contact: {}", cartesian_contact.transpose()));
+      plan_.reset();     // reset unique ptr
+      plan_utime_ = -1;  // reset plan to -1
+      return franka::MotionFinished(output_to_franka);
+    }
+  }
+
   if (auto overtime {franka_time_ - plan_end_time};
       overtime > 0) {  // check for convergence when overtime
     // Maximum change in joint angle between two confs

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -851,6 +851,10 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
   }
   output_to_franka = utils::EigenToArray(output_to_franka_eigen);
 
+  // if the robot does not actually make contact along the expected contact
+  // axis until the end of the plan, the driver will publish plan complete.
+  // it is on the user to send a plan that goes past the expected contact
+  // point
   if (plan_exec_opt_ == robot_msgs::plan_exec_opts_t::MOVE_UNTIL_STOP) {
     Eigen::Map<const Eigen::Matrix<double, 6, 1>> cartesian_contact(
         robot_state.cartesian_contact.data());

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -55,8 +55,8 @@
 #include <string>
 #include <thread>  // for thread
 
-#include <robot_msgs/robot_spline_t.hpp>  // for robot_spline_t
 #include <robot_msgs/plan_exec_opts_t.hpp>
+#include <robot_msgs/robot_spline_t.hpp>  // for robot_spline_t
 
 #include "driver/communication_interface.h"  // for CommunicationInterface
 #include "driver/constraint_solver.h"        // for ConstraintSolver
@@ -234,8 +234,9 @@ class FrankaPlanRunner {
   std::unique_ptr<franka::Robot> robot_ {};
   std::unique_ptr<CommunicationInterface> comm_interface_;
   std::unique_ptr<PPType> plan_;
-  int64_t plan_utime_ = -1;
-  int64_t plan_exec_opt_ = robot_msgs::plan_exec_opts_t::DEFAULT;
+  int64_t plan_utime_ {-1};
+  int64_t plan_exec_opt_ {robot_msgs::plan_exec_opts_t::DEFAULT};
+  Eigen::Vector3d contact_expected_ {Eigen::Vector3d::Zero()};
   std::unique_ptr<ConstraintSolver> constraint_solver_;
 
   // keeping track of time along plan:

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -56,6 +56,7 @@
 #include <thread>  // for thread
 
 #include <robot_msgs/robot_spline_t.hpp>  // for robot_spline_t
+#include <robot_msgs/plan_exec_opts_t.hpp>
 
 #include "driver/communication_interface.h"  // for CommunicationInterface
 #include "driver/constraint_solver.h"        // for ConstraintSolver
@@ -234,6 +235,7 @@ class FrankaPlanRunner {
   std::unique_ptr<CommunicationInterface> comm_interface_;
   std::unique_ptr<PPType> plan_;
   int64_t plan_utime_ = -1;
+  int64_t plan_exec_opt_ = robot_msgs::plan_exec_opts_t::DEFAULT;
   std::unique_ptr<ConstraintSolver> constraint_solver_;
 
   // keeping track of time along plan:

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -135,9 +135,9 @@ class FrankaPlanRunner {
     // lower_force_thresholds_nominal,
     // upper_force_thresholds_nominal
     robot_->setCollisionBehavior(
-        upper_torque_threshold_, upper_torque_threshold_,
-        upper_torque_threshold_, upper_torque_threshold_,
-        upper_force_threshold_, upper_force_threshold_, upper_force_threshold_,
+        lower_torque_threshold_, upper_torque_threshold_,
+        lower_torque_threshold_, upper_torque_threshold_,
+        lower_force_threshold_, upper_force_threshold_, lower_force_threshold_,
         upper_force_threshold_);
   }
 
@@ -290,6 +290,8 @@ class FrankaPlanRunner {
                                                     100.0, 100.0, 100.0};
   const std::array<double, 7> kMediumTorqueThreshold {40.0, 40.0, 36.0, 36.0,
                                                       32.0, 28.0, 24.0};
+  const std::array<double, 7> kLowTorqueThreshold {20.0, 20.0, 18.0, 18.0,
+                                                   16.0, 14.0, 12.0};
   const std::array<double, 7> kImpedanceControlTorqueThreshold {
       87.0, 87.0, 87.0, 87.0, 12.0, 12.0, 12.0};
 
@@ -298,9 +300,11 @@ class FrankaPlanRunner {
                                                    100.0, 100.0, 100.0};
   const std::array<double, 6> kMediumForceThreshold {40.0, 40.0, 40.0,
                                                      50.0, 50.0, 50.0};
+  const std::array<double, 6> kLowForceThreshold {20.0, 20.0, 20.0,
+                                                  25.0, 25.0, 25.0};
 
-  std::array<double, 7> upper_torque_threshold_;
-  std::array<double, 6> upper_force_threshold_;
+  std::array<double, 7> lower_torque_threshold_, upper_torque_threshold_;
+  std::array<double, 6> lower_force_threshold_, upper_force_threshold_;
 
   // The following two constants must be tuned together.
   // A higher speed threshold may result in the benign libfranka exception:

--- a/src/utils/util_conv.cc
+++ b/src/utils/util_conv.cc
@@ -123,14 +123,14 @@ drake::lcmt_iiwa_status ConvertToLcmStatus(
 
   robot_status.joint_velocity_estimated = ArrayToVector(robot_state.dq);
 
-
   robot_status.joint_torque_measured = ArrayToVector(robot_state.tau_J);
   robot_status.joint_torque_commanded = ArrayToVector(robot_state.tau_J_d);
 
-  // NOTE: We use the currently unused external joint torques array to send cartesian
-  // contact info for testing purposes. This is a temporary workaround until we update
-  // the iiwa_status lcm message include these fields
-  robot_status.joint_torque_external = ArrayToVector(robot_state.cartesian_contact);
+  // NOTE: We use the currently unused external joint torques array to send
+  // cartesian contact info for testing purposes. This is a temporary workaround
+  // until we update the iiwa_status lcm message include these fields
+  robot_status.joint_torque_external =
+      ArrayToVector(robot_state.cartesian_contact);
   robot_status.joint_torque_external.resize(num_joints, 0);
 
   return robot_status;

--- a/src/utils/util_conv.cc
+++ b/src/utils/util_conv.cc
@@ -122,8 +122,12 @@ drake::lcmt_iiwa_status ConvertToLcmStatus(
   robot_status.joint_position_ipo = e_to_v(robot_plan_next_conf);
 
   robot_status.joint_velocity_estimated = ArrayToVector(robot_state.dq);
+
+
   robot_status.joint_torque_measured = ArrayToVector(robot_state.tau_J);
-  robot_status.joint_torque_commanded = ArrayToVector(robot_state.tau_J_d);
+
+  robot_status.joint_torque_commanded = ArrayToVector(robot_state.joint_contact);
+  robot_status.joint_torque_external = ArrayToVector(robot_state.cartesian_contact);
   robot_status.joint_torque_external.resize(num_joints, 0);
 
   return robot_status;

--- a/src/utils/util_conv.cc
+++ b/src/utils/util_conv.cc
@@ -125,8 +125,11 @@ drake::lcmt_iiwa_status ConvertToLcmStatus(
 
 
   robot_status.joint_torque_measured = ArrayToVector(robot_state.tau_J);
+  robot_status.joint_torque_commanded = ArrayToVector(robot_state.tau_J_d);
 
-  robot_status.joint_torque_commanded = ArrayToVector(robot_state.joint_contact);
+  // NOT: We use the currently unused external joint torques array to send cartesian
+  // contact info for testing purposes. This is a temporary workaround until we update
+  // the iiwa_status lcm message include these fields
   robot_status.joint_torque_external = ArrayToVector(robot_state.cartesian_contact);
   robot_status.joint_torque_external.resize(num_joints, 0);
 

--- a/src/utils/util_conv.cc
+++ b/src/utils/util_conv.cc
@@ -127,7 +127,7 @@ drake::lcmt_iiwa_status ConvertToLcmStatus(
   robot_status.joint_torque_measured = ArrayToVector(robot_state.tau_J);
   robot_status.joint_torque_commanded = ArrayToVector(robot_state.tau_J_d);
 
-  // NOT: We use the currently unused external joint torques array to send cartesian
+  // NOTE: We use the currently unused external joint torques array to send cartesian
   // contact info for testing purposes. This is a temporary workaround until we update
   // the iiwa_status lcm message include these fields
   robot_status.joint_torque_external = ArrayToVector(robot_state.cartesian_contact);

--- a/src/utils/util_conv.cc
+++ b/src/utils/util_conv.cc
@@ -129,6 +129,8 @@ drake::lcmt_iiwa_status ConvertToLcmStatus(
   // NOTE: We use the currently unused external joint torques array to send
   // cartesian contact info for testing purposes. This is a temporary workaround
   // until we update the iiwa_status lcm message include these fields
+  // TODO(@anyone): update iiwa_status lcm message and get rid of these
+  // workarounds
   robot_status.joint_torque_external =
       ArrayToVector(robot_state.cartesian_contact);
   robot_status.joint_torque_external.resize(num_joints, 0);

--- a/src/utils/util_conv.h
+++ b/src/utils/util_conv.h
@@ -98,22 +98,19 @@ inline drake::math::RigidTransformd ToRigidTransform(
  */
 inline drake::math::RigidTransformd ToRigidTransform(
     const Eigen::Affine3d& xform_eigen) {
-  const Eigen::Matrix4d& mat {xform_eigen.matrix()};
-  return drake::math::RigidTransformd(mat);
+  return drake::math::RigidTransformd(xform_eigen.matrix());
 }
 
 /**
  * @brief Utility function that takes converts a pose
  * from `drake::math::RigidTransformd` to `Eigen::Affine3d`
- * which can be mapped to an std::array for efficient 
+ * which can be mapped to an std::array for efficient
  *
  * @param xform pose as `drake::math::RigidTransformd`
  * @return pose as `Eigen::Affine3d`
  */
 inline Eigen::Affine3d ToAffine3d(const drake::math::RigidTransformd& xform) {
-  Eigen::Affine3d result_affine3d {};
-  result_affine3d = xform.GetAsMatrix4();
-  return result_affine3d;
+  return Eigen::Affine3d(xform.GetAsMatrix4());
 }
 
 }  //  namespace utils

--- a/src/utils/util_conv.h
+++ b/src/utils/util_conv.h
@@ -71,4 +71,24 @@ drake::lcmt_iiwa_status EigenToLcmStatus(Eigen::VectorXd robot_state);
 franka::RobotState ConvertToCannonical(const franka::RobotState& robot_state,
                                        const Eigen::VectorXd& offsets);
 
+inline drake::math::RigidTransformd ToRigidTransform(
+    const bot_core::position_3d_t& pos3dt) {
+  return {Eigen::Quaterniond(pos3dt.rotation.w, pos3dt.rotation.x,
+                             pos3dt.rotation.y, pos3dt.rotation.z),
+          Eigen::Vector3d(pos3dt.translation.x, pos3dt.translation.y,
+                          pos3dt.translation.z)};
+}
+
+inline drake::math::RigidTransformd ToRigidTransform(
+    const Eigen::Affine3d& xform_eigen) {
+  const Eigen::Matrix4d& mat {xform_eigen.matrix()};
+  return drake::math::RigidTransformd(mat);
+}
+
+inline Eigen::Affine3d ToAffine3d(const drake::math::RigidTransformd& xform) {
+  Eigen::Affine3d result_affine3d {};
+  result_affine3d = xform.GetAsMatrix4();
+  return result_affine3d;
+}
+
 }  //  namespace utils

--- a/src/utils/util_conv.h
+++ b/src/utils/util_conv.h
@@ -71,6 +71,14 @@ drake::lcmt_iiwa_status EigenToLcmStatus(Eigen::VectorXd robot_state);
 franka::RobotState ConvertToCannonical(const franka::RobotState& robot_state,
                                        const Eigen::VectorXd& offsets);
 
+/**
+ * @brief Utility function that takes converts a pose
+ * from `bot_core::position_3d_t` to `drake::math::RigidTransformd`
+ * which is more convenient for calculations
+ *
+ * @param pos3dt pose as `bot_core::position_3d_t`
+ * @return pose as `drake::math::RigidTransformd`
+ */
 inline drake::math::RigidTransformd ToRigidTransform(
     const bot_core::position_3d_t& pos3dt) {
   return {Eigen::Quaterniond(pos3dt.rotation.w, pos3dt.rotation.x,
@@ -79,12 +87,29 @@ inline drake::math::RigidTransformd ToRigidTransform(
                           pos3dt.translation.z)};
 }
 
+/**
+ * @brief Utility function that takes converts a pose
+ * from `Eigen::Affine3d` to `drake::math::RigidTransformd`
+ * which is more convenient for calculations and is widely
+ * used in our code base
+ *
+ * @param xform_eigen pose as `Eigen::Affine3d`
+ * @return pose as `drake::math::RigidTransformd`
+ */
 inline drake::math::RigidTransformd ToRigidTransform(
     const Eigen::Affine3d& xform_eigen) {
   const Eigen::Matrix4d& mat {xform_eigen.matrix()};
   return drake::math::RigidTransformd(mat);
 }
 
+/**
+ * @brief Utility function that takes converts a pose
+ * from `drake::math::RigidTransformd` to `Eigen::Affine3d`
+ * which can be mapped to an std::array for efficient 
+ *
+ * @param xform pose as `drake::math::RigidTransformd`
+ * @return pose as `Eigen::Affine3d`
+ */
 inline Eigen::Affine3d ToAffine3d(const drake::math::RigidTransformd& xform) {
   Eigen::Affine3d result_affine3d {};
   result_affine3d = xform.GetAsMatrix4();


### PR DESCRIPTION
### Background
- Process `cartesian_goal` and `exec_opt` in `robot_spline_t`
- Execute plan until contact as specified by `cartesian_goal`

### What's new
- ✅ Process `cartesian_goal` and `exec_opt` in `robot_spline_t`
- ✅ Execute plan until contact as specified by `cartesian_goal`

### Related work
- ✅❌ https://github.com/DexaiRobotics/dig/pull/813 needs this PR

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: [Ran tool change with tool centering on vine on `jello`]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
