### PR TITLE
Sw.mode.unknown

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -396,6 +396,7 @@ bool CommunicationInterface::CanReceiveCommands(
       return false;
     default:
       dexai::log()->error("CanReceiveCommands: Mode unknown!");
+      PublishDriverStatus(false, "Franka controller mode unknown");
       return false;
   }
 }

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -417,7 +417,6 @@ bool CommunicationInterface::CanReceiveCommands(
       return false;
     default:
       dexai::log()->error("CanReceiveCommands: Mode unknown!");
-      PublishDriverStatus(false, "Franka controller mode unknown");
       return false;
   }
 }
@@ -448,6 +447,8 @@ void CommunicationInterface::HandlePlan(
     if (ModeIsValid(current_mode)) {
       break;
     }
+    PublishDriverStatus(false,
+                        "Franka controller is reporting an unknown mode");
     log()->error("HandlePlan: attempt {}/{} to read control mode from Franka",
                  i + 1, max_mode_check_attempts);
     current_mode = GetRobotMode();

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -191,6 +191,10 @@ class CommunicationInterface {
     return lcm_brakes_locked_channel_;
   }
 
+  /// check if robot mode corresponds to one of the known control modes from the
+  /// controller, return false if the mode is garbage
+  static bool ModeIsValid(const franka::RobotMode& current_mode);
+
   /// check if robot is in a mode that can receive commands, i.e. not user
   /// stopped or error recovery
   static bool CanReceiveCommands(const franka::RobotMode& current_mode);

--- a/src/utils/util_conv.cc
+++ b/src/utils/util_conv.cc
@@ -69,6 +69,8 @@ std::string RobotModeToString(franka::RobotMode mode) {
     case franka::RobotMode::kAutomaticErrorRecovery:
       mode_string = "Automatic Error Recovery";
       break;
+    default:
+      mode_string = "Unknown";
   }
   return mode_string;
 }


### PR DESCRIPTION
### Background

- Some auto-retry and better reporting when we get garbage mode values from Franka controller

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- ✅❌ This PR needs [link]
- ✅❌ [link] needs this PR

### TODOs / Nice-To-Haves
- ❌ [Add new unit test for new feature.]
- ❌ [Add new system test for new feature.]

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅❌ New code is written in pure C++17 to the best of my knowledge.
4. ✅❌ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
