### PR TITLE
Fix segfault on user-triggered control exception in sim driver

### DIFF
--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -84,6 +84,10 @@ class FrankaPlanRunner {
   // collision behaviour is set by SetCollisionBehaviorSafetyOn
   // and SetCollisionBehaviorSafetyOff
   void SetDefaultBehaviorForInit() {
+    if (is_sim_) {
+      return;
+    }
+
     robot_->setCollisionBehavior(
         // lower_torque_thresholds_acceleration
         {20, 20, 20, 20, 10, 10, 10},
@@ -121,6 +125,10 @@ class FrankaPlanRunner {
   // TODO(@syler): can we just set the lower threshold to something reasonable
   // and get away with only increasing the upper threshold?
   void SetCollisionBehaviorSafetyOn() {
+    if (is_sim_) {
+      return;
+    }
+
     if (const auto mode {GetRobotMode()}; mode == franka::RobotMode::kMove) {
       throw std::runtime_error("robot is in mode: "
                                + utils::RobotModeToString(mode)
@@ -143,6 +151,10 @@ class FrankaPlanRunner {
   }
 
   void SetCollisionBehaviorSafetyOff() {
+    if (is_sim_) {
+      return;
+    }
+
     if (const auto mode {GetRobotMode()}; mode == franka::RobotMode::kMove) {
       throw std::runtime_error("robot is in mode: "
                                + utils::RobotModeToString(mode)


### PR DESCRIPTION
### Background
Fix segfault on user-triggered control exception in sim driver 

### What's new
- ✅ Fix segfault on user-triggered control exception in sim driver 

### Tests
1. ✅ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅❌ New code is written in pure C++17 to the best of my knowledge.
4. ✅❌ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
