### PR TITLE
Remove print statement saying franka failed to start if driver is killed

### DIFF
--- a/franka.sh
+++ b/franka.sh
@@ -59,10 +59,6 @@ if lcm-echo -n 1 -v 0 --timeout 0.1 ${status_channel}; then
     exit 1
 fi
 
-if ./build/franka_driver $config $@; then
-    echo "franka_driver started successfully"
-else
-    echo "franka_driver failed to start"
-fi
+./build/franka_driver $config $@
 
 popd


### PR DESCRIPTION
### Background

- Remove print statement saying franka failed to start if driver is killed

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- ✅❌ This PR needs [link]
- ✅❌ [link] needs this PR

### TODOs / Nice-To-Haves
- ❌ [Add new unit test for new feature.]
- ❌ [Add new system test for new feature.]

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅❌ New code is written in pure C++17 to the best of my knowledge.
4. ✅❌ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
