### PR TITLE
Use new collision filter management from Drake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: dexai2/drake-torch:cpu-nightly-ros-latest
+      - image: dexai2/drake-torch:cpu-stable-ros-latest
 
     steps:
       - run:

--- a/src/driver/constraint_solver.cc
+++ b/src/driver/constraint_solver.cc
@@ -130,7 +130,8 @@ ConstraintSolver::ConstraintSolver(const RobotParameters* params)
     // cannot call {} because no {GeometrySet} constructor is available
     drake::geometry::GeometrySet set_robot(
         mb_plant.CollectRegisteredGeometries(robot_bodies));
-    scene_graph.ExcludeCollisionsWithin(set_robot);
+    scene_graph.collision_filter_manager().Apply(
+        drake::geometry::CollisionFilterDeclaration().ExcludeWithin(set_robot));
   }
 
   // allow for visualization


### PR DESCRIPTION
### Background
Resolved deprecation warning from Drake by switching to the newer collision filter management workflow.

### What's new
- ✅ Doesn't have Drake Deprecation warning
- ❌ New feature is accompanied by new test: Same behavior, different workflow.

### Related work
- ✅❌ This PR in paired with [dig/#1087](https://github.com/DexaiRobotics/dig/pull/1087)

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
