### PR TITLE
Loosen tolerance for reporting divergence after plan completion

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -1034,7 +1034,7 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
     // terminate plan if grace period has ended and still not converged
     // in both position and speed after the deadline
     if (franka_time_ > (plan_->end_time() + 0.1)) {  // 100 ms
-      if (max_joint_err < 1e-4) {
+      if (max_joint_err < 2e-3) {
         // converged in position, publish success and don't wait for speed
         dexai::log()->warn(
             "JointPositionCallback: plan {} overtime by {:.4f} s, grace period "


### PR DESCRIPTION
### Background
Increases the joint angle error tolerance for reporting success after the plan has exceeded the grace period.

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
