### PR TITLE
fix: set robot state when not idle

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -208,6 +208,13 @@ int FrankaPlanRunner::RunFranka() {
             utils::get_current_utime(),
             comm_interface_->GetBrakesLockedChannelName(),
             current_mode == franka::RobotMode::kOther);
+        // Set robot state here so we're still publishing an accurate state
+        auto robot_state {robot_->readOnce()};
+        auto cannonical_robot_state {
+            utils::ConvertToCannonical(robot_state, joint_pos_offset_)};
+        comm_interface_->SetRobotData(cannonical_robot_state, next_conf_plan_,
+                                      franka_time_, plan_utime_,
+                                      plan_start_utime_);
 
         if (t_now - t_last_main_loop_log_ >= std::chrono::seconds(1)) {
           dexai::log()->error("RunFranka: {}", err_msg);


### PR DESCRIPTION
### Background
Set the robot state when we're in a mode other than Idle, so that TLE can finish starting up when we're in a mode other than idle. 

### What's new
- ✅  Set the robot state when we're in a mode other than Idle, so that TLE can finish starting up when we're in a mode other than idle. 

### Related work
- ✅❌ This PR needs [link]
- ✅❌ [link] needs this PR

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: Tested on udon by starting the franka driver with the ustop engaged and confirming we still have a > 0 DOF status publish

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
