### PR TITLE
Fix publishing rate for brakes locked, ustop, and driver status

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -619,8 +619,7 @@ void CommunicationInterface::HandlePause(
     default:
       dexai::log()->error(
           "CommInterface:HandlePause: ignoring unknown pause command type "
-          "from "
-          "source: {}",
+          "from source: {}",
           source);
       break;
   }

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -275,23 +275,6 @@ void CommunicationInterface::PublishLcmAndPauseStatus() {
     PublishRobotStatus();
     // TODO(@anyone): make pause status part of the robot status
     PublishPauseStatus();
-    // publish user stop, brakes locked, and driver status
-
-    if (std::unique_lock<std::mutex> lock {robot_data_mutex_};
-        robot_data_.has_robot_data) {
-      franka::RobotMode current_mode {robot_data_.robot_state.robot_mode};
-      lock.unlock();
-      auto utime {utils::get_current_utime()};
-
-      if ((current_mode == franka::RobotMode::kUserStopped)
-          || (current_mode == franka::RobotMode::kOther)) {
-        // publish if robot is user stopped or locked
-        PublishBoolToChannel(utime, GetUserStopChannelName(),
-                             current_mode == franka::RobotMode::kUserStopped);
-        PublishBoolToChannel(utime, GetBrakesLockedChannelName(),
-                             current_mode == franka::RobotMode::kOther);
-      }
-    }
 
     // publish driver status
     {

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -232,7 +232,8 @@ void CommunicationInterface::SetPauseStatus(bool paused) {
 }
 
 void CommunicationInterface::PublishPlanComplete(
-    const int64_t& plan_utime, bool success, std::string plan_status_string) {
+    const int64_t plan_utime, const bool success,
+    const std::string& plan_status_string) {
   std::string log_msg {
       fmt::format("CommInterface:PublishPlanComplete: plan {} {}", plan_utime,
                   success ? "successful" : "failed")};
@@ -246,15 +247,8 @@ void CommunicationInterface::PublishPlanComplete(
                           success, plan_status_string);
 }
 
-void CommunicationInterface::SetDriverStatus(bool success,
-                                             std::string driver_status_string) {
-  std::scoped_lock<std::mutex> lock {driver_status_mutex_};
-  driver_status_.running = success;
-  driver_status_.message = driver_status_string;
-}
-
 void CommunicationInterface::PublishDriverStatus(
-    bool success, std::string driver_status_string) {
+    const bool success, const std::string& driver_status_string) {
   PublishTriggerToChannel(utils::get_current_utime(),
                           lcm_driver_status_channel_, success,
                           driver_status_string);

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -102,6 +102,12 @@ struct PauseData {
   std::set<std::string> pause_sources;
 };
 
+/// A struct to describe the current status of the driver.
+struct DriverStatus {
+  bool running;
+  std::string message;
+};
+
 struct RobotPlanBuffer {
   int64_t utime;
   int16_t exec_opt;
@@ -194,6 +200,9 @@ class CommunicationInterface {
   void PublishPlanComplete(const int64_t& plan_utime, bool success = true,
                            std::string driver_status_string = "");
 
+  // set driver status
+  bool SetDriverStatus(bool success, std::string driver_status_string = "");
+
   void PublishDriverStatus(bool success, std::string driver_status_string = "");
   void PublishBoolToChannel(int64_t utime, std::string_view lcm_channel,
                             bool data);
@@ -267,6 +276,10 @@ class CommunicationInterface {
 
   PauseData pause_data_;
   std::mutex pause_mutex_;
+
+  // TODO(@syler): consolidate into robot status
+  DriverStatus driver_status_;
+  std::mutex driver_status_mutex_;
 
   std::thread lcm_publish_status_thread_;
   std::thread lcm_handle_thread_;

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -201,7 +201,7 @@ class CommunicationInterface {
                            std::string driver_status_string = "");
 
   // set driver status
-  bool SetDriverStatus(bool success, std::string driver_status_string = "");
+  void SetDriverStatus(bool success, std::string driver_status_string = "");
 
   void PublishDriverStatus(bool success, std::string driver_status_string = "");
   void PublishBoolToChannel(int64_t utime, std::string_view lcm_channel,

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -197,13 +197,19 @@ class CommunicationInterface {
     return pause_data_.pause_sources;
   }
 
-  void PublishPlanComplete(const int64_t& plan_utime, bool success = true,
-                           std::string driver_status_string = "");
+  void PublishPlanComplete(const int64_t plan_utime, const bool success = true,
+                           const std::string& driver_status_string = "");
 
   // set driver status
-  void SetDriverStatus(bool success, std::string driver_status_string = "");
+  inline void SetDriverStatus(const bool success,
+                              const std::string& driver_status_string = "") {
+    std::scoped_lock<std::mutex> lock {driver_status_mutex_};
+    driver_status_.running = success;
+    driver_status_.message = driver_status_string;
+  }
 
-  void PublishDriverStatus(bool success, std::string driver_status_string = "");
+  void PublishDriverStatus(const bool success,
+                           const std::string& driver_status_string = "");
   void PublishBoolToChannel(int64_t utime, std::string_view lcm_channel,
                             bool data);
   void PublishPauseToChannel(int64_t utime, std::string_view lcm_channel,

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -325,7 +325,7 @@ int FrankaPlanRunner::RunFranka() {
             comm_interface_->SetRobotData(cannonical_robot_state,
                                           next_conf_plan_, franka_time_,
                                           plan_utime_, plan_start_utime_);
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
           }
         }
         continue;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -325,7 +325,7 @@ int FrankaPlanRunner::RunFranka() {
             comm_interface_->SetRobotData(cannonical_robot_state,
                                           next_conf_plan_, franka_time_,
                                           plan_utime_, plan_start_utime_);
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
           }
         }
         continue;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -198,16 +198,6 @@ int FrankaPlanRunner::RunFranka() {
             fmt::format("robot cannot receive commands in mode: {} at startup",
                         utils::RobotModeToString(current_mode))};
         comm_interface_->SetDriverStatus(false, err_msg);
-
-        // publish if robot is user stopped or locked on startup
-        comm_interface_->PublishBoolToChannel(
-            utils::get_current_utime(),
-            comm_interface_->GetUserStopChannelName(),
-            current_mode == franka::RobotMode::kUserStopped);
-        comm_interface_->PublishBoolToChannel(
-            utils::get_current_utime(),
-            comm_interface_->GetBrakesLockedChannelName(),
-            current_mode == franka::RobotMode::kOther);
         // Set robot state here so we're still publishing an accurate state
         auto robot_state {robot_->readOnce()};
         auto cannonical_robot_state {


### PR DESCRIPTION
### Background

- Fix high LCM publish rate when robot is user stopped by removing duplicate publishing

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### TODOs / Nice-To-Haves
- ❌ Consolidate into publishing all aspects of robot status (brakes locked, user stop, driver status) into single LCM channel

### Tests
1. ✅ Tested on simulated robot: Tested `back_and_forth`
2. ✅ Tested on physical robot: Tested publish rate when user stopped during operation and on startup, and `back_and_forth`

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
