### PR TITLE
Publish to consolidated driver status message

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -301,8 +301,8 @@ void CommunicationInterface::PublishRobotStatus() {
           current_mode == franka::RobotMode::kUserStopped;
       driver_status_msg_.robot_mode = utils::RobotModeToString(current_mode);
       driver_status_msg_.compliant_push_active = compliant_push_active_;
+      lcm_.publish(lcm_driver_status_channel_, &driver_status_msg_);
     }
-    lcm_.publish(lcm_driver_status_channel_, &driver_status_msg_);
 
     // Cancel robot plans if robot is U-stopped.
     if (current_mode == franka::RobotMode::kUserStopped) {

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -445,7 +445,7 @@ void CommunicationInterface::HandlePlan(
     if (ModeIsValid(current_mode)) {
       break;
     }
-    SetDriverStatus(false, "Franka controller is reporting an unknown mode");
+    SetDriverIsRunning(false, "Franka controller is reporting an unknown mode");
     log()->error("HandlePlan: attempt {}/{} to read control mode from Franka",
                  i + 1, max_mode_check_attempts);
     current_mode = GetRobotMode();
@@ -457,7 +457,7 @@ void CommunicationInterface::HandlePlan(
         "Discarding plan with utime: {}, robot is in wrong mode: {}!",
         robot_spline->utime, utils::RobotModeToString(current_mode))};
     dexai::log()->error("CommInterface:HandlePlan: {}", err_msg);
-    SetDriverStatus(false, err_msg);
+    SetDriverIsRunning(false, err_msg);
     return;
   }
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -324,8 +324,8 @@ robot_msgs::driver_status_t CommunicationInterface::GetUpdatedDriverStatus(
     driver_status_msg_.pause_sources.clear();
     driver_status_msg_.num_pause_sources = pause_data_.pause_sources.size();
     if (pause_data_.paused) {
-      for (auto elem : pause_data_.pause_sources) {
-        driver_status_msg_.pause_sources.push_back(elem);
+      for (const auto& source : pause_data_.pause_sources) {
+        driver_status_msg_.pause_sources.push_back(source);
       }
     }
   }

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -290,6 +290,7 @@ void CommunicationInterface::PublishRobotStatus() {
           current_mode == franka::RobotMode::kOther;
       driver_status_msg_.user_stopped =
           current_mode == franka::RobotMode::kUserStopped;
+      driver_status_msg_.robot_mode = utils::RobotModeToString(current_mode);
       driver_status_msg_.compliant_push_active = compliant_push_active_;
       driver_status_msg_.torque_enabled = true;
     }

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -230,8 +230,16 @@ void CommunicationInterface::PublishPlanComplete(
   dexai::log()->info(log_msg);
   new_plan_buffer_.plan.reset();
   new_plan_buffer_.cartesian_plan.reset();
-  PublishTriggerToChannel(plan_utime, params_.lcm_plan_complete_channel,
-                          success, plan_status_string);
+
+  {
+    std::scoped_lock<std::mutex> status_lock {driver_status_mutex_};
+    driver_status_msg_.last_plan_utime = plan_utime;
+    driver_status_msg_.last_plan_successful = success;
+    driver_status_msg_.last_plan_msg = plan_status_string;
+  }
+
+  // PublishTriggerToChannel(plan_utime, params_.lcm_plan_complete_channel,
+  //                         success, plan_status_string);
 }
 
 void CommunicationInterface::HandleLcm() {

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -96,6 +96,15 @@ CommunicationInterface::CommunicationInterface(const RobotParameters& params,
                      lcm_driver_status_channel_);
   dexai::log()->info("Sim driver event trigger channel:\t{}",
                      lcm_sim_driver_event_trigger_channel_);
+
+  {
+    std::scoped_lock<std::mutex> status_lock {driver_status_mutex_};
+    driver_status_msg_.current_plan_utime = -1;
+    driver_status_msg_.plan_start_utime = -1;
+    driver_status_msg_.last_plan_utime = -1;
+    driver_status_msg_.last_plan_successful = false;
+    driver_status_msg_.torque_enabled = true;
+  }
 };
 
 void CommunicationInterface::ResetData() {
@@ -292,7 +301,6 @@ void CommunicationInterface::PublishRobotStatus() {
           current_mode == franka::RobotMode::kUserStopped;
       driver_status_msg_.robot_mode = utils::RobotModeToString(current_mode);
       driver_status_msg_.compliant_push_active = compliant_push_active_;
-      driver_status_msg_.torque_enabled = true;
     }
     lcm_.publish(lcm_driver_status_channel_, &driver_status_msg_);
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -576,8 +576,7 @@ void CommunicationInterface::HandlePause(
     }
     case PauseCommandType::PAUSE:
       dexai::log()->warn(
-          "CommInterface:HandlePause: received pause command from source: "
-          "{}",
+          "CommInterface:HandlePause: received pause command from source: {}",
           source);
       if (pause_data_.pause_sources.insert(source).second == false) {
         dexai::log()->warn(
@@ -588,8 +587,7 @@ void CommunicationInterface::HandlePause(
     case PauseCommandType::CONTINUE:
       dexai::log()->warn(
           "CommInterface:HandlePause: received continue command from "
-          "source: "
-          "{}",
+          "source: {}",
           source);
       if (pause_data_.pause_sources.find(source)
           != pause_data_.pause_sources.end()) {
@@ -618,8 +616,8 @@ void CommunicationInterface::HandlePause(
   }
 }
 
-// TODO(@syler): this could be a different message type, pause_cmd is
-// probably not the best here
+// TODO(@syler): this could be a different message type, pause_cmd is probably
+// not the best here
 void CommunicationInterface::HandleSimDriverEventTrigger(
     const ::lcm::ReceiveBuffer*, const std::string&,
     const robot_msgs::pause_cmd* cmd_msg) {

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -314,16 +314,16 @@ void CommunicationInterface::PublishRobotStatus() {
 void CommunicationInterface::SetPauseStatus() {
   std::unique_lock<std::mutex> lock(pause_mutex_);
   bool paused {pause_data_.paused};
-  std::string pause_sources {""};
+  std::vector<std::string> pause_sources {};
   if (pause_data_.paused) {
     for (auto elem : pause_data_.pause_sources) {
-      pause_sources.append(elem);
-      pause_sources.append(",");
+      pause_sources.push_back(elem);
     }
   }
   lock.unlock();
   std::scoped_lock<std::mutex> status_lock {driver_status_mutex_};
   driver_status_msg_.paused = paused;
+  driver_status_msg_.num_pause_sources = pause_sources.size();
   driver_status_msg_.pause_sources = pause_sources;
 }
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -316,7 +316,6 @@ robot_msgs::driver_status_t CommunicationInterface::GetUpdatedDriverStatus(
   driver_status_msg_.user_stopped =
       current_mode == franka::RobotMode::kUserStopped;
   driver_status_msg_.robot_mode = utils::RobotModeToString(current_mode);
-  robot_data_mutex_.unlock();
   driver_status_msg_.compliant_push_active = compliant_push_active_;
 
   {

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -58,6 +58,7 @@
 
 #include <lcm/lcm-cpp.hpp>
 #include <robot_msgs/bool_t.hpp>
+#include <robot_msgs/driver_status_t.hpp>
 #include <robot_msgs/pause_cmd.hpp>
 #include <robot_msgs/plan_exec_opts_t.hpp>
 #include <robot_msgs/robot_spline_t.hpp>
@@ -214,6 +215,8 @@ class CommunicationInterface {
     std::scoped_lock<std::mutex> lock {driver_status_mutex_};
     driver_status_.running = success;
     driver_status_.message = driver_status_string;
+    driver_status_msg_.driver_running = success;
+    driver_status_msg_.err_msg = driver_status_string;
   }
 
   void PublishDriverStatus();
@@ -293,6 +296,7 @@ class CommunicationInterface {
 
   // TODO(@syler): consolidate into robot status
   DriverStatus driver_status_;
+  robot_msgs::driver_status_t driver_status_msg_;
   std::mutex driver_status_mutex_;
 
   std::thread lcm_publish_status_thread_;

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -203,15 +203,18 @@ class CommunicationInterface {
   void SetPlanCompletion(const int64_t plan_utime, const bool success = true,
                          const std::string& driver_status_string = "");
 
-  // set driver status
-  inline void SetDriverStatus(const bool success,
-                              const std::string& driver_status_string = "") {
+  /// Set driver status fields with running status and error message.
+  inline void SetDriverIsRunning(const bool success,
+                                 const std::string& driver_status_string = "") {
     std::scoped_lock<std::mutex> lock {driver_status_mutex_};
     driver_status_msg_.driver_running = success;
     driver_status_msg_.err_msg = driver_status_string;
   }
 
-  void PublishDriverStatus();
+  robot
+
+      void
+      PublishDriverStatus();
   void PublishBoolToChannel(const int64_t utime, std::string_view lcm_channel,
                             const bool data);
   void PublishPauseToChannel(const int64_t utime, std::string_view lcm_channel,

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -211,10 +211,9 @@ class CommunicationInterface {
     driver_status_msg_.err_msg = driver_status_string;
   }
 
-  robot
+  /// Update driver status and return publishable status message.
+  robot_msgs::driver_status_t GetUpdatedDriverStatus();
 
-      void
-      PublishDriverStatus();
   void PublishBoolToChannel(const int64_t utime, std::string_view lcm_channel,
                             const bool data);
   void PublishPauseToChannel(const int64_t utime, std::string_view lcm_channel,
@@ -237,7 +236,6 @@ class CommunicationInterface {
   /// indicating the contents of the pause message.
   void PublishLcmAndPauseStatus();
   void PublishRobotStatus();
-  void SetPauseStatus();
   void PublishTriggerToChannel(const int64_t utime,
                                std::string_view lcm_channel,
                                const bool success = true,

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -234,7 +234,7 @@ class CommunicationInterface {
   /// indicating the contents of the pause message.
   void PublishLcmAndPauseStatus();
   void PublishRobotStatus();
-  void PublishPauseStatus();
+  void SetPauseStatus();
   void PublishTriggerToChannel(const int64_t utime,
                                std::string_view lcm_channel,
                                const bool success = true,
@@ -288,7 +288,6 @@ class CommunicationInterface {
   std::thread lcm_handle_thread_;
 
   std::string lcm_driver_status_channel_;
-  std::string lcm_pause_status_channel_;
   std::string lcm_user_stop_channel_;
   std::string lcm_compliant_push_req_channel_;
   std::string lcm_brakes_locked_channel_;

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -91,12 +91,6 @@ struct RobotData {
   // utime at start of current plan
   int64_t plan_start_utime {};
 
-  // utime of the last completed plan.
-  int64_t last_plan_utime {};
-
-  // true if last plan was completed successfully
-  bool last_plan_successful {};
-
   // plan completion fraction.
   // should be in [0, 1]
   double plan_completion_frac {};
@@ -107,12 +101,6 @@ struct RobotData {
 struct PauseData {
   std::atomic<bool> paused;
   std::set<std::string> pause_sources;
-};
-
-/// A struct to describe the current status of the driver.
-struct DriverStatus {
-  bool running;
-  std::string message;
 };
 
 struct RobotPlanBuffer {
@@ -219,8 +207,6 @@ class CommunicationInterface {
   inline void SetDriverStatus(const bool success,
                               const std::string& driver_status_string = "") {
     std::scoped_lock<std::mutex> lock {driver_status_mutex_};
-    driver_status_.running = success;
-    driver_status_.message = driver_status_string;
     driver_status_msg_.driver_running = success;
     driver_status_msg_.err_msg = driver_status_string;
   }
@@ -295,8 +281,6 @@ class CommunicationInterface {
   PauseData pause_data_;
   std::mutex pause_mutex_;
 
-  // TODO(@syler): consolidate into robot status
-  DriverStatus driver_status_;
   robot_msgs::driver_status_t driver_status_msg_;
   std::mutex driver_status_mutex_;
 

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -183,6 +183,9 @@ class CommunicationInterface {
   // acquire mutex lock and return robot mode
   franka::RobotMode GetRobotMode();
 
+  /// Manual mode switch in sim as opposed to reading from Franka controller
+  void SetModeIfSimulated(const franka::RobotMode& mode);
+
   // Set the robot state, blocking
   void SetRobotData(const franka::RobotState& robot_state,
                     const Eigen::VectorXd& robot_plan_next_conf,
@@ -212,7 +215,8 @@ class CommunicationInterface {
   }
 
   /// Update driver status and return publishable status message.
-  robot_msgs::driver_status_t GetUpdatedDriverStatus();
+  robot_msgs::driver_status_t GetUpdatedDriverStatus(
+      const int64_t utime, const RobotData& robot_data);
 
   void PublishBoolToChannel(const int64_t utime, std::string_view lcm_channel,
                             const bool data);

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -447,6 +447,8 @@ bool FrankaPlanRunner::RecoverFromControlException() {
   if (plan_) {
     ResetPlan();
   }
+  // if simulated, manually switch from reflex to idle
+  comm_interface_->SetModeIfSimulated(franka::RobotMode::kIdle);
   // TODO(@syler): reset this once it has been published once?
   comm_interface_->SetDriverIsRunning(
       true, "successfully completed automatic error recovery");

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -819,13 +819,12 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
   if (comm_interface_->SimControlExceptionTriggered()) {
     dexai::log()->warn(
         "JointPositionCallback: simulated control exception triggered");
-    RecoverFromControlException();
-    comm_interface_->ClearSimControlExceptionTrigger();
     // return current joint positions instead of running plan through to
     // completion
     comm_interface_->SetPlanCompletion(plan_utime_, false,
                                        "simulated control exception");
-
+    RecoverFromControlException();
+    comm_interface_->ClearSimControlExceptionTrigger();
     return franka::MotionFinished(franka::JointPositions(robot_state.q));
   }
 

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -271,6 +271,7 @@ class FrankaPlanRunner {
       const Eigen::Matrix<double, 7, 7> inertia);
 
   inline void ResetPlan() {
+    dexai::log()->debug("ResetPlan: begin");
     plan_.reset();
     plan_utime_ = -1;
     plan_start_utime_ = -1;

--- a/src/utils/robot_parameters.cc
+++ b/src/utils/robot_parameters.cc
@@ -135,10 +135,7 @@ bool RobotParameters::GenerateParametersBasedOnRobotName(
   lcm_iiwa_status_channel = new_robot_name + "_STATUS";
   lcm_robot_status_channel = new_robot_name + "_ROBOT_STATUS";
   lcm_plan_channel = new_robot_name + "_PLAN";
-  lcm_plan_received_channel = new_robot_name + "_PLAN_RECEIVED";
-  lcm_plan_complete_channel = new_robot_name + "_PLAN_COMPLETE";
   lcm_stop_channel = new_robot_name + "_STOP";
-  lcm_user_stop_channel = new_robot_name + "_USER_STOPPED";
   lcm_compliant_push_req_channel = new_robot_name + "_COMPLIANT_PUSH_REQ";
 
   return true;
@@ -256,10 +253,7 @@ RobotParameters loadYamlParameters(
     p.lcm_iiwa_status_channel = p.robot_name + "_STATUS";
     p.lcm_robot_status_channel = p.robot_name + "_ROBOT_STATUS";
     p.lcm_plan_channel = p.robot_name + "_PLAN";
-    p.lcm_plan_received_channel = p.robot_name + "_PLAN_RECEIVED";
-    p.lcm_plan_complete_channel = p.robot_name + "_PLAN_COMPLETE";
     p.lcm_stop_channel = p.robot_name + "_STOP";
-    p.lcm_user_stop_channel = p.robot_name + "_USER_STOPPED";
     p.lcm_compliant_push_req_channel = p.robot_name + "_COMPLIANT_PUSH_REQ";
     get_yaml_val_or_die(param, "lcm_url", p.lcm_url, yaml_full_path, verbose,
                         exit_code);

--- a/src/utils/robot_parameters.h
+++ b/src/utils/robot_parameters.h
@@ -185,10 +185,7 @@ class RobotParameters {
   std::string lcm_iiwa_status_channel;
   std::string lcm_robot_status_channel;
   std::string lcm_plan_channel;
-  std::string lcm_plan_received_channel;
-  std::string lcm_plan_complete_channel;
   std::string lcm_stop_channel;
-  std::string lcm_user_stop_channel;
   std::string lcm_compliant_push_req_channel;
 
   std::string lcm_url;


### PR DESCRIPTION
### Background

Consolidate multiple LCM channels into single driver status channel with information about current plan number, user stop, brakes, pause, torque status and other driver metadata.

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Related work

- [ ] https://github.com/DexaiRobotics/dig/pull/1535
- [ ] https://github.com/DexaiRobotics/ancillary_arm/pull/168
- [x] https://github.com/DexaiRobotics/robot_msgs/pull/34)
- [ ] https://github.com/DexaiRobotics/robot_workstationlib/pull/88
- [ ] https://github.com/DexaiRobotics/robot_workstation/pull/127


### Tests
1. ✅  Tested on simulated robot: tested `back_and_forth` with control exceptions
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
