### PR TITLE
Catch all Franka exceptions, not just ControlException, during init

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -195,12 +195,12 @@ int FrankaPlanRunner::RunFranka() {
               "RunFranka: automaticErrorRecovery succeeded, out of Reflex mode,"
               " now in mode: {}.",
               utils::RobotModeToString(GetRobotMode()));
-        } catch (const franka::ControlException& ce) {
-          comm_interface_->SetDriverIsRunning(false, ce.what());
+        } catch (const franka::Exception& e) {
+          comm_interface_->SetDriverIsRunning(false, e.what());
           dexai::log()->warn(
-              "RunFranka: control exception in initialisation during automatic "
+              "RunFranka: caught exception in initialisation during automatic "
               "error recovery for Reflex mode: {}.",
-              ce.what());
+              e.what());
         }
       } else if (current_mode != franka::RobotMode::kIdle) {  // any other mode
         auto err_msg {


### PR DESCRIPTION
### Background

Fixes crash when `CommandException` is thrown: 
```
franka-driver-deploy | [2021-12-14 17:26:23.768] [franka_driver] [warning] RunFranka: robot is in Reflex mode at startup, trying automaticErrorRecovery...
franka-driver-deploy | terminate called after throwing an instance of 'franka::CommandException'
franka-driver-deploy |   what():  libfranka: Automatic Error Recovery command rejected: manual error recovery required!
franka-driver-deploy | /src/drake-franka-driver/franka.sh: line 62:    14 Aborted                 (core dumped) ./build/franka_driver $config $@
franka-driver-deploy | ~
```

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
