### PR TITLE
Fix driver crash on real robot when a simulated control exception is triggered

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -452,9 +452,7 @@ bool FrankaPlanRunner::RecoverFromControlException() {
   }
   // if simulated, manually switch from reflex to idle
   comm_interface_->SetModeIfSimulated(franka::RobotMode::kIdle);
-  // TODO(@syler): reset this once it has been published once?
-  comm_interface_->SetDriverIsRunning(
-      true, "successfully completed automatic error recovery");
+  comm_interface_->SetDriverIsRunning(true);
   return true;
 }
 

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -421,8 +421,11 @@ bool FrankaPlanRunner::RecoverFromControlException() {
   status_ = RobotStatus::Reversing;
   dexai::log()->warn("RecoverFromControlException: turning safety off...");
   SetCollisionBehaviorSafetyOff();
+  dexai::log()->warn("RecoverFromControlException: set safety off.");
   if (!is_sim_) {
     auto current_mode {GetRobotMode()};
+    dexai::log()->error("RecoverFromControlException: in mode {}",
+                        utils::RobotModeToString(current_mode));
     if ((current_mode == franka::RobotMode::kUserStopped)
         || (current_mode == franka::RobotMode::kOther)) {
       auto err_msg {

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -824,9 +824,12 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
         "JointPositionCallback: simulated control exception triggered");
     // return current joint positions instead of running plan through to
     // completion
-    comm_interface_->SetPlanCompletion(plan_utime_, false,
-                                       "simulated control exception");
+
+    // copy plan utime, this gets reset when recovering from control exception
+    const auto last_plan_utime {plan_utime_};
     RecoverFromControlException();
+    comm_interface_->SetPlanCompletion(last_plan_utime, false,
+                                       "simulated control exception");
     comm_interface_->ClearSimControlExceptionTrigger();
     return franka::MotionFinished(franka::JointPositions(robot_state.q));
   }


### PR DESCRIPTION
### Background

- Fix driver crash on real robot when a simulated control exception is triggered

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].


### Tests
1. ✅ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: ran `back_and_forth` with `cmd franka driver_event control_exception`
### Quality
3. ✅New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
