### PR TITLE
Add timing on plan preprocessing before execution

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -250,7 +250,7 @@ void CommunicationInterface::SetPlanCompletion(
 
   dexai::log()->info(
       "CommInterface:SetPlanCompletion: plan {} timing breakdown: input "
-      "checking: {} ms, confirmation: {} ms, execution start: {}",
+      "checking: {} ms, confirmation: {} ms, execution start: {} ms",
       plan_utime, ms_accept, ms_confirm, ms_start);
 }
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -238,20 +238,20 @@ void CommunicationInterface::SetPlanCompletion(
   }
   SetModeIfSimulated(franka::RobotMode::kIdle);
 
-  const auto t1 {
+  const auto ms_accept {
       duration_cast<chrono_ms>(timepoints_.t_accepted - timepoints_.t_received)
           .count()};
-  const auto t2 {
+  const auto ms_confirm {
       duration_cast<chrono_ms>(timepoints_.t_confirmed - timepoints_.t_received)
           .count()};
-  const auto t3 {
+  const auto ms_start {
       duration_cast<chrono_ms>(timepoints_.t_started - timepoints_.t_received)
           .count()};
 
   dexai::log()->info(
       "CommInterface:SetPlanCompletion: plan {} timing breakdown: input "
       "checking: {} ms, confirmation: {} ms, execution start: {}",
-      plan_utime, t1, t2, t3);
+      plan_utime, ms_accept, ms_confirm, ms_start);
 }
 
 void CommunicationInterface::HandleLcm() {
@@ -578,18 +578,19 @@ void CommunicationInterface::HandlePlan(
   }
   lock.unlock();
 
-  auto t_end {hr_clock::now()};
   timepoints_.t_received = t_start;
-  timepoints_.t_accepted = t_end;
+  timepoints_.t_accepted = hr_clock::now();
 
   dexai::log()->info(
       "CommInterface:HandlePlan: populated buffer with new plan {}",
       new_plan_buffer_.utime);
-  auto delta_time {duration_cast<chrono_ms>(t_end - t_start).count()};
+  auto ms_accept {
+      duration_cast<chrono_ms>(timepoints_.t_accepted - timepoints_.t_received)
+          .count()};
 
   dexai::log()->info(
       "CommInterface:HandlePlan: Finished input checking plan {} in {} ms",
-      new_plan_buffer_.utime, delta_time);
+      new_plan_buffer_.utime, ms_accept);
 }
 
 void CommunicationInterface::HandlePause(

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -241,20 +241,26 @@ void CommunicationInterface::SetPlanCompletion(
   }
   SetModeIfSimulated(franka::RobotMode::kIdle);
 
-  const auto ms_accept {
-      duration_cast<chrono_ms>(timepoints_.t_accepted - timepoints_.t_received)
-          .count()};
-  const auto ms_confirm {
-      duration_cast<chrono_ms>(timepoints_.t_confirmed - timepoints_.t_received)
-          .count()};
-  const auto ms_start {
-      duration_cast<chrono_ms>(timepoints_.t_started - timepoints_.t_received)
-          .count()};
+  // sanity check and make sure we have all the timepoints, as plans can be
+  // received and accepted but not make it to confirmation and execution
+  if (plan_utime == timepoints_.utime && timepoints_.t_confirmed.has_value()
+      && timepoints_.t_started.has_value()) {
+    const auto ms_accept {duration_cast<chrono_ms>(timepoints_.t_accepted
+                                                   - timepoints_.t_received)
+                              .count()};
+    const auto ms_confirm {
+        duration_cast<chrono_ms>(timepoints_.t_confirmed.value()
+                                 - timepoints_.t_received)
+            .count()};
+    const auto ms_start {duration_cast<chrono_ms>(timepoints_.t_started.value()
+                                                  - timepoints_.t_received)
+                             .count()};
 
-  dexai::log()->info(
-      "CommInterface:SetPlanCompletion: plan {} timing breakdown: input "
-      "checking: {} ms, confirmation: {} ms, execution start: {} ms",
-      plan_utime, ms_accept, ms_confirm, ms_start);
+    dexai::log()->info(
+        "CommInterface:SetPlanCompletion: plan {} timing breakdown: input "
+        "checking: {} ms, confirmation: {} ms, execution start: {} ms",
+        plan_utime, ms_accept, ms_confirm, ms_start);
+  }
 }
 
 void CommunicationInterface::HandleLcm() {

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -108,6 +108,7 @@ struct PauseData {
 };
 
 struct PlanTimepoints {
+  int64_t utime;
   std::chrono::time_point<hr_clock> t_received;
   std::chrono::time_point<hr_clock> t_accepted;
   std::chrono::time_point<hr_clock> t_confirmed;
@@ -120,6 +121,7 @@ struct RobotPlanBuffer {
   Eigen::Vector3d contact_expected {};
   std::unique_ptr<PPType> plan;
   std::unique_ptr<PosePoly> cartesian_plan;
+  PlanTimepoints timepoints;
 };
 
 class CommunicationInterface {
@@ -158,6 +160,10 @@ class CommunicationInterface {
     compliant_push_active_ = active;
   }
 
+  inline void SetPlanTimepoints(const PlanTimepoints& timepoints) {
+    timepoints_ = timepoints;
+  }
+
   inline void LogPlanExecutionStartTime() {
     timepoints_.t_started = hr_clock::now();
   }
@@ -184,9 +190,11 @@ class CommunicationInterface {
     new_plan_buffer_.utime = -1;
   }
 
-  std::tuple<std::unique_ptr<PPType>, int64_t, int16_t, Eigen::Vector3d>
+  std::tuple<std::unique_ptr<PPType>, int64_t, int16_t, Eigen::Vector3d,
+             PlanTimepoints>
   PopNewPlan();
-  std::tuple<std::unique_ptr<PosePoly>, int64_t, int16_t> PopNewCartesianPlan();
+  std::tuple<std::unique_ptr<PosePoly>, int64_t, int16_t, PlanTimepoints>
+  PopNewCartesianPlan();
 
   // TODO(@anyone): remove franka specific RobotState type and
   // replace with std::array

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -70,6 +70,10 @@
 using drake::trajectories::PiecewisePolynomial;
 using drake::trajectories::PiecewisePose;
 
+using hr_clock = std::chrono::high_resolution_clock;
+using chrono_ms = std::chrono::milliseconds;
+using std::chrono::duration_cast;
+
 typedef PiecewisePolynomial<double> PPType;
 typedef PiecewisePose<double> PosePoly;
 
@@ -101,6 +105,13 @@ struct RobotData {
 struct PauseData {
   std::atomic<bool> paused;
   std::set<std::string> pause_sources;
+};
+
+struct PlanTimepoints {
+  std::chrono::time_point<hr_clock> t_received;
+  std::chrono::time_point<hr_clock> t_accepted;
+  std::chrono::time_point<hr_clock> t_confirmed;
+  std::chrono::time_point<hr_clock> t_started;
 };
 
 struct RobotPlanBuffer {
@@ -145,6 +156,10 @@ class CommunicationInterface {
 
   inline void SetCompliantPushActive(const bool active) {
     compliant_push_active_ = active;
+  }
+
+  inline void LogPlanExecutionStartTime() {
+    timepoints_.t_started = hr_clock::now();
   }
 
   bool CancelPlanRequested() const { return cancel_plan_requested_; }
@@ -288,6 +303,8 @@ class CommunicationInterface {
   std::mutex robot_data_mutex_;
 
   PauseData pause_data_;
+  PlanTimepoints timepoints_;
+
   std::mutex pause_mutex_;
 
   robot_msgs::driver_status_t driver_status_msg_;

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -111,8 +111,8 @@ struct PlanTimepoints {
   int64_t utime;
   std::chrono::time_point<hr_clock> t_received;
   std::chrono::time_point<hr_clock> t_accepted;
-  std::chrono::time_point<hr_clock> t_confirmed;
-  std::chrono::time_point<hr_clock> t_started;
+  std::optional<std::chrono::time_point<hr_clock>> t_confirmed {};
+  std::optional<std::chrono::time_point<hr_clock>> t_started {};
 };
 
 struct RobotPlanBuffer {

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -829,6 +829,8 @@ void FrankaPlanRunner::UpdateActivePlan(
   }
 
   end_conf_plan_ = plan_->value(plan_->end_time());
+
+  comm_interface_->LogPlanExecutionStartTime();
 }
 
 franka::JointPositions FrankaPlanRunner::JointPositionCallback(

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -799,8 +799,8 @@ bool FrankaPlanRunner::IsStartFarFromCurrentJointPosition(
 
 void FrankaPlanRunner::UpdateActivePlan(
     std::unique_ptr<PPType> new_plan, int64_t new_plan_utime,
-    int64_t new_plan_exec_opt,
-    const Eigen::Vector3d& new_plan_contact_expected) {
+    int64_t new_plan_exec_opt, const Eigen::Vector3d& new_plan_contact_expected,
+    const PlanTimepoints& new_plan_timepoints) {
   const bool has_active_plan {plan_ != nullptr};
   plan_ = std::move(new_plan);
   plan_utime_ = new_plan_utime;
@@ -830,6 +830,7 @@ void FrankaPlanRunner::UpdateActivePlan(
 
   end_conf_plan_ = plan_->value(plan_->end_time());
 
+  comm_interface_->SetPlanTimepoints(new_plan_timepoints);
   comm_interface_->LogPlanExecutionStartTime();
 }
 
@@ -870,7 +871,8 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
 
   if (comm_interface_->HasNewPlan()) {  // pop the new plan and set it up
     auto [new_plan, new_plan_utime, new_plan_exec_opt,
-          new_plan_contact_expected] {comm_interface_->PopNewPlan()};
+          new_plan_contact_expected,
+          new_plan_timepoints] {comm_interface_->PopNewPlan()};
 
     bool has_active_plan {plan_ != nullptr};
     bool is_new_plan_valid {!new_plan->empty()
@@ -882,7 +884,7 @@ franka::JointPositions FrankaPlanRunner::JointPositionCallback(
       // plan. Or if we do not currently have a plan, move the new plan's
       // ownership to the current plan unique_ptr
       UpdateActivePlan(std::move(new_plan), new_plan_utime, new_plan_exec_opt,
-                       new_plan_contact_expected);
+                       new_plan_contact_expected, new_plan_timepoints);
       // the current (desired) position of franka is the starting position:
       start_conf_franka_ = current_conf_franka;
 

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -241,10 +241,13 @@ class FrankaPlanRunner {
    * @param new_plan_exec_opt - execution options associated with the new plan
    * @param new_plan_contact_expected - unit vector in the direction of expected
    * contact assiciated with the new plan. if any
+   * @param new_plan_timepoints - struct containing times when plan was received
+   * and accepted
    */
   void UpdateActivePlan(std::unique_ptr<PPType> new_plan,
                         int64_t new_plan_utime, int64_t new_plan_exec_opt,
-                        const Eigen::Vector3d& new_plan_contact_expected);
+                        const Eigen::Vector3d& new_plan_contact_expected,
+                        const PlanTimepoints& new_plan_timepoints);
 
   /// Set parameters for stiffness and goal direction based on push direction.
   /// TODO(@anyone): long-term the stiffness can be a parameter of the push


### PR DESCRIPTION
### Background

- Add timing on plan preprocessing before execution

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Tests
1. ✅ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
