### PR TITLE
Publish driver status even if robot is locked

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -302,6 +302,9 @@ void CommunicationInterface::PublishRobotStatus() {
       utils::ConvertToLcmIiwaStatus(robot_data_)};
   auto driver_status_msg {
       GetUpdatedDriverStatus(franka_status.utime, robot_data_)};
+  // TODO(@syler): we don't continuosly update robot data when robot is in
+  // reflex/automatic error recovery mode so those modes will never be reflected
+  // in driver status
   lcm_.publish(lcm_driver_status_channel_, &driver_status_msg);
 
   if (robot_data_.has_robot_data) {

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -298,14 +298,13 @@ void CommunicationInterface::PublishRobotStatus() {
   // Try to lock data to avoid read write collisions.
   std::unique_lock<std::mutex> lock {robot_data_mutex_};
 
+  drake::lcmt_iiwa_status franka_status {
+      utils::ConvertToLcmIiwaStatus(robot_data_)};
   auto driver_status_msg {
       GetUpdatedDriverStatus(franka_status.utime, robot_data_)};
   lcm_.publish(lcm_driver_status_channel_, &driver_status_msg);
 
   if (robot_data_.has_robot_data) {
-    drake::lcmt_iiwa_status franka_status {
-        utils::ConvertToLcmIiwaStatus(robot_data_)};
-
     robot_msgs::robot_status_t robot_status {
         utils::ConvertToRobotStatusLcmMsg(robot_data_)};
 

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -296,8 +296,13 @@ void CommunicationInterface::PublishLcmAndPauseStatus() {
 
 void CommunicationInterface::PublishRobotStatus() {
   // Try to lock data to avoid read write collisions.
-  if (std::unique_lock<std::mutex> lock {robot_data_mutex_};
-      robot_data_.has_robot_data) {
+  std::unique_lock<std::mutex> lock {robot_data_mutex_};
+
+  auto driver_status_msg {
+      GetUpdatedDriverStatus(franka_status.utime, robot_data_)};
+  lcm_.publish(lcm_driver_status_channel_, &driver_status_msg);
+
+  if (robot_data_.has_robot_data) {
     drake::lcmt_iiwa_status franka_status {
         utils::ConvertToLcmIiwaStatus(robot_data_)};
 
@@ -306,15 +311,11 @@ void CommunicationInterface::PublishRobotStatus() {
 
     franka::RobotMode current_mode {robot_data_.robot_state.robot_mode};
 
-    auto driver_status_msg {
-        GetUpdatedDriverStatus(franka_status.utime, robot_data_)};
-
     robot_data_.has_robot_data = false;
     lock.unlock();
     // publish data over lcm
     lcm_.publish(params_.lcm_iiwa_status_channel, &franka_status);
     lcm_.publish(params_.lcm_robot_status_channel, &robot_status);
-    lcm_.publish(lcm_driver_status_channel_, &driver_status_msg);
 
     // Cancel robot plans if robot is U-stopped.
     if (current_mode == franka::RobotMode::kUserStopped) {

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -441,9 +441,7 @@ bool FrankaPlanRunner::RecoverFromControlException() {
                         utils::RobotModeToString(current_mode))};
         dexai::log()->error("RecoverFromControlException: {}", err_msg);
         comm_interface_->SetDriverIsRunning(false, err_msg);
-        // if error recovery fails because we are in the wrong mode, need user
-        // to intervene, so wait
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        return false;
       } else {
         dexai::log()->warn(
             "RecoverFromControlException: turning safety off...");

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -418,7 +418,7 @@ int FrankaPlanRunner::RunFranka() {
 }
 
 bool FrankaPlanRunner::RecoverFromControlException() {
-  dexai::log()->error(
+  dexai::log()->debug(
       "RecoverFromControlException: attempting to perform automatic error "
       "recovery");
 
@@ -429,9 +429,6 @@ bool FrankaPlanRunner::RecoverFromControlException() {
   if (!is_sim_) {
     auto current_mode {GetRobotMode()};
     do {
-      dexai::log()->error("RecoverFromControlException: in mode {}",
-                          utils::RobotModeToString(current_mode));
-
       if ((current_mode == franka::RobotMode::kUserStopped)
           || (current_mode == franka::RobotMode::kOther)) {
         // setting collision behavior and performing error recovery will fail if


### PR DESCRIPTION
### Background

- Publish driver status even if robot is locked

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- https://github.com/DexaiRobotics/dig/pull/1875 needs this PR

### TODOs / Nice-To-Haves
- ❌ [Add new unit test for new feature.]
- ❌ [Add new system test for new feature.]

### Tests
1. ❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
