### PR TITLE
Expand try catch in automatic error recovery

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -442,12 +442,12 @@ bool FrankaPlanRunner::RecoverFromControlException() {
       } else {
         dexai::log()->warn(
             "RecoverFromControlException: turning safety off...");
-        SetCollisionBehaviorSafetyOff();
-        dexai::log()->warn("RecoverFromControlException: set safety off.");
-        dexai::log()->warn(
-            "RecoverFromControlException: running Franka's automatic error "
-            "recovery...");
         try {
+          SetCollisionBehaviorSafetyOff();
+          dexai::log()->warn("RecoverFromControlException: set safety off.");
+          dexai::log()->warn(
+              "RecoverFromControlException: running Franka's automatic error "
+              "recovery...");
           robot_->automaticErrorRecovery();
         } catch (const franka::Exception& e) {
           const auto err_msg {

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -443,6 +443,29 @@ bool FrankaPlanRunner::RecoverFromControlException() {
         dexai::log()->warn(
             "RecoverFromControlException: turning safety off...");
         try {
+          // Attemts to set collision behavior and perform automatic error
+          // recovery will throw a franka::CommandException if the robot is in
+          // the wrong mode which does not support that. We already check that
+          // the robot is not locked or user stopped in the outer if statement,
+          // but have observed crashes even with that logic in place.
+
+          // It is not well understood yet what modes led to the above, so have
+          // a try-catch around the commands that would issue
+          // franka::CommandException and allow us to proceed with the logic and
+          // print additional information on the exception and robot's current
+          // mode.
+
+          // We are relying on library code from libfranka as the source of the
+          // error in question, triggered by a specific set of circumstances in
+          // the physical world. In order to unit test we would need a
+          // multithreaded setup where we could mock the robot mode and throw an
+          // exception at a very specific time in execution of the logic. We
+          // don't enough information to write the unit test if the
+          // capability existed as we don't have enough insight into what the
+          // state of the libfranka interface WAS at the time.
+
+          // TODO(@syler): update above comment and logic once we have more
+          // information, add unit test
           SetCollisionBehaviorSafetyOff();
           dexai::log()->warn("RecoverFromControlException: set safety off.");
           dexai::log()->warn(


### PR DESCRIPTION
### Background

- Follow-on to https://github.com/DexaiRobotics/drake-franka-driver/pull/132 as setting collision behavior also issues a command exception
- https://dexai.slack.com/archives/CTUFJ4WVA/p1664899362058659?thread_ts=1664899343.578519&cid=CTUFJ4WVA

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- https://github.com/DexaiRobotics/drake-franka-driver/pull/132
### Tests
1. ❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
