### PR TITLE
One line change: ForcedPublish for compatibility with Drake 1.10

### DIFF
--- a/src/driver/constraint_solver.cc
+++ b/src/driver/constraint_solver.cc
@@ -230,7 +230,7 @@ void ConstraintSolver::UpdateModel(
   // TODO(@anyone): set this based on visualization level
   // this performs the magic of making the diagram publish to the visualizer.
   // not needed for the actual collision check.
-  simulator_->get_system().Publish(simulator_->get_context());
+  simulator_->get_system().ForcedPublish(simulator_->get_context());
 }
 
 }  // namespace franka_driver


### PR DESCRIPTION
### Background

`Publish` Method is deprecated in Drake 1.10. Replacing it with `ForcedPublish`

### Needs to be merged with this PR:
https://github.com/DexaiRobotics/fullstack/pull/2952 

### Tests
1. ✅ Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅❌ New code is written in pure C++17 to the best of my knowledge.
4. ✅❌ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
