### PR TITLE
chore: build libfranka with gcc9; update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.11.4
     hooks:
     - id: isort
       types: [python]
       args: [--filter-files]
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.12.0
     hooks:
     - id: black
       args: [--line-length, '79']
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     - id: flake8
       exclude: scripts/robot_msgs/
@@ -25,17 +25,17 @@ repos:
       args: [--rcfile=setup.cfg]
       exclude: scripts/robot_msgs/
 -   repo: https://github.com/pycqa/pydocstyle
-    rev: 5.1.1
+    rev: 6.3.0
     hooks:
     - id: pydocstyle
       exclude: scripts/robot_msgs/
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
+    rev: v0.991
     hooks:
     - id: mypy
       exclude: scripts/robot_msgs/
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
     - id: check-added-large-files
       args: [--maxkb=100]
@@ -65,7 +65,7 @@ repos:
     - id: trailing-whitespace
       exclude: '.*[.](urdf|obj|lcm|lcmlog)$'
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.4.2
     hooks:
     - id: forbid-crlf
     - id: remove-crlf
@@ -168,7 +168,7 @@ repos:
              "--suppress=unusedFunction"
              ]
 -   repo: https://github.com/pocc/pre-commit-hooks
-    rev: 41ad32113ed5abe9c33a01f606b5eacf572b13e0
+    rev: v1.3.5
     hooks:
     - id: oclint
       # keep the original compile_commands.json as oclint requires it

--- a/setup.sh
+++ b/setup.sh
@@ -92,12 +92,12 @@ if [ ! -f "build/libfranka.so" ]; then
     if (( $build_debug > 0 )); then
         echo "Build libfranka in Debug mode!"
         cmake .. -DCMAKE_BUILD_TYPE=Debug \
-                 -DCMAKE_C_COMPILER=gcc-7 \
-                 -DCMAKE_CXX_COMPILER=g++-7
+                 -DCMAKE_C_COMPILER=gcc-9 \
+                 -DCMAKE_CXX_COMPILER=g++-9
     else
         cmake .. -DCMAKE_BUILD_TYPE=Release \
-                 -DCMAKE_C_COMPILER=gcc-7 \
-                 -DCMAKE_CXX_COMPILER=g++-7
+                 -DCMAKE_C_COMPILER=gcc-9 \
+                 -DCMAKE_CXX_COMPILER=g++-9
     fi
     cmake --build . -j $num_threads --target franka communication_test
     popd
@@ -121,10 +121,10 @@ fi
 mkdir -p build; cd build
 if (( $build_debug > 0 )); then
     echo "Building in debug mode"
-    cmake .. -G Ninja -D CMAKE_BUILD_TYPE=Debug     || exit 4   # Build for debugging
+    cmake .. -D CMAKE_BUILD_TYPE=Debug     || exit 4   # Build for debugging
 else
     echo "Building in release mode"
-    cmake .. -G Ninja -D CMAKE_BUILD_TYPE=Release   || exit 5
+    cmake .. -D CMAKE_BUILD_TYPE=Release   || exit 5
 fi
 
 cmake --build . --target $target -- -j $num_threads || exit 6


### PR DESCRIPTION
### Background

gcc7 is deprecated in the ubuntu apt universe. gcc9 is the last compatible compiler for libfranka 0.8 and it won't build on anything newer. we should upgrade soon

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- This PR needs [link]
- [link] needs this PR

### TODOs / Nice-To-Haves
- ❌ [Add new unit test for new feature.]
- ❌ [Add new system test for new feature.]

### Tests
1. ✅ Tested on simulated robot: [Describe the tests/commands used.]
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
