### PR TITLE
Revert accidental change added in #137

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -404,17 +404,9 @@ void CommunicationInterface::SetModeIfSimulated(const franka::RobotMode& mode) {
                utils::RobotModeToString(mode));
   if (is_sim_) {
     std::scoped_lock<std::mutex> lock {robot_data_mutex_};
-    auto current_mode {robot_data_.robot_state.robot_mode};
-    if (current_mode == franka::RobotMode::kUserStopped) {
-      log()->warn(
-          "CommInterface:SetModeIfSimulated: failed to set mode to {} as "
-          "Franka is user stopped",
-          utils::RobotModeToString(mode));
-    } else {
-      robot_data_.robot_state.robot_mode = mode;
-      log()->info("CommInterface:SetModeIfSimulated: set mode to {}",
-                  utils::RobotModeToString(mode));
-    }
+    robot_data_.robot_state.robot_mode = mode;
+    log()->info("CommInterface:SetModeIfSimulated: set mode to {}",
+                utils::RobotModeToString(mode));
   }
 }
 


### PR DESCRIPTION
### Background

- Follow up to revert accidentally committed change from https://github.com/DexaiRobotics/drake-franka-driver/pull/137

### What's new
- ✅ [New feature description. Only a single new major feature is allowed per PR.]
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- ✅❌ This PR needs [link]
- ✅❌ [link] needs this PR

### TODOs / Nice-To-Haves
- ❌ [Add new unit test for new feature.]
- ❌ [Add new system test for new feature.]

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅❌ New code is written in pure C++17 to the best of my knowledge.
4. ✅❌ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅❌ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅❌ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
