### PR TITLE
reduce log verbosity when we fail to init in reflex mode

### DIFF
--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -198,12 +198,16 @@ int FrankaPlanRunner::RunFranka() {
           // reset to 0 when we're successful
           reflex_init_recovery_attempts_ = 0;
         } catch (const franka::Exception& e) {
-          // Sleep before attempting to retry with exponential backoff. Avoids logspam in the case that we can't get out of reflex mode on init with out user help.
-          const auto wait_time_seconds {std::pow(2.0, reflex_init_recovery_attempts_)};
+          // Sleep before attempting to retry with exponential backoff. Avoids
+          // logspam in the case that we can't get out of reflex mode on init
+          // with out user help.
+          const auto wait_time_seconds {
+              std::pow(2.0, reflex_init_recovery_attempts_)};
           comm_interface_->SetDriverIsRunning(false, e.what());
           dexai::log()->warn(
               "RunFranka: caught exception in initialisation during automatic "
-              "error recovery for Reflex mode: {}. Sleeping {} sec before attempting again.",
+              "error recovery for Reflex mode: {}. Sleeping {} sec before "
+              "attempting again.",
               e.what(), wait_time_seconds);
           std::this_thread::sleep_for(
               std::chrono::duration<double>(wait_time_seconds));

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -411,6 +411,9 @@ class FrankaPlanRunner {
 
   Eigen::Vector3d desired_position_;
   Eigen::Quaterniond desired_orientation_;
+
+  // number of attempts to automatically recover from being in reflex mode on init
+  size_t reflex_init_recovery_attempts_ {};
 };  // FrankaPlanRunner
 
 }  // namespace franka_driver


### PR DESCRIPTION
### Background
reduce log verbosity by increasing how long we wait between retries, when we fail to init in reflex mode. fixes: https://dexairobotics.atlassian.net/browse/DEX-7215

### What's new
- ✅ reduce log verbosity when we fail to init in reflex mode. 

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
