### PR TITLE
Clear next plan when recovering from user stop

### DIFF
--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -615,10 +615,18 @@ void CommunicationInterface::HandlePause(
 
   switch (pause_type) {
     case PauseCommandType::CANCEL_PLAN: {
-      dexai::log()->debug(
-          "CommInterface:HandlePause: Received cancel plan request with "
-          "source: {}",
-          source);
+      const auto err_msg {
+          fmt::format("CommInterface:HandlePause: Received cancel plan request "
+                      "with source: {}",
+                      source)};
+      // warn on first user stop cancellation received (we publish continuously
+      // until resolved)
+      if (source == fmt::format("{}_U_STOP", params_.robot_name)
+          && !cancel_plan_requested_) {
+        dexai::log()->warn(err_msg);
+      } else {
+        dexai::log()->debug(err_msg);
+      }
       cancel_plan_requested_ = true;
       cancel_plan_source_ = source;
       break;

--- a/src/driver/communication_interface.cc
+++ b/src/driver/communication_interface.cc
@@ -619,10 +619,9 @@ void CommunicationInterface::HandlePause(
           fmt::format("CommInterface:HandlePause: Received cancel plan request "
                       "with source: {}",
                       source)};
-      // warn on first user stop cancellation received (we publish continuously
-      // until resolved)
-      if (source == fmt::format("{}_U_STOP", params_.robot_name)
-          && !cancel_plan_requested_) {
+      // warn on first cancellation received (we publish continuously until
+      // resolved)
+      if (!cancel_plan_requested_) {
         dexai::log()->warn(err_msg);
       } else {
         dexai::log()->debug(err_msg);

--- a/src/driver/communication_interface.h
+++ b/src/driver/communication_interface.h
@@ -302,7 +302,7 @@ class CommunicationInterface {
   int64_t last_confirmed_plan_utime_;
 
   // This is a buffer storing the new plan received. Capacility is only 1.
-  // Once this plan is popped (taken), this buffer is emptied and avialable
+  // Once this plan is popped (taken), this buffer is emptied and available
   // to store a new plan, while the current plan may be running.
   RobotPlanBuffer new_plan_buffer_;
   std::mutex robot_plan_mutex_;

--- a/src/driver/franka_plan_runner.cc
+++ b/src/driver/franka_plan_runner.cc
@@ -399,7 +399,7 @@ int FrankaPlanRunner::RunFranka() {
     } else {  // unable to receive commands because robot is in a wrong mode
       if (comm_interface_->HasNewPlan()) {  // clear plan
         std::string err_msg {
-            fmt::format("buffered plan discarded because robot is now in mode "
+            fmt::format("Buffered plan discarded because robot is now in mode "
                         "{}, unable to receive plan",
                         utils::RobotModeToString(mode))};
         comm_interface_->ClearNewPlan(err_msg);
@@ -468,6 +468,13 @@ bool FrankaPlanRunner::RecoverFromControlException() {
                         utils::RobotModeToString(current_mode))};
         dexai::log()->error("RecoverFromControlException: {}", err_msg);
         comm_interface_->SetDriverIsRunning(false, err_msg);
+        if (comm_interface_->HasNewPlan()) {
+          const auto clear_plan_msg {fmt::format(
+              "After robot has transitioned out of mode: {}, receipt "
+              "of a new plan is required to proceed",
+              utils::RobotModeToString(current_mode))};
+          comm_interface_->ClearNewPlan(clear_plan_msg);
+        }
         return false;
       } else {
         dexai::log()->warn(

--- a/src/driver/franka_plan_runner.h
+++ b/src/driver/franka_plan_runner.h
@@ -412,7 +412,8 @@ class FrankaPlanRunner {
   Eigen::Vector3d desired_position_;
   Eigen::Quaterniond desired_orientation_;
 
-  // number of attempts to automatically recover from being in reflex mode on init
+  // number of attempts to automatically recover from being in reflex mode on
+  // init
   size_t reflex_init_recovery_attempts_ {};
 };  // FrankaPlanRunner
 


### PR DESCRIPTION
### Background

In situations where communication between the Franka controller and driver is interrupted, and a user stop is subsequently issued to the Franka, it is possible for the release of the user stop to result in the system erroneously resuming motion without user input. Deeper dive [here](https://dexai.slack.com/archives/C03R65J58LV/p1706215664331639?thread_ts=1706109164.478469&cid=C03R65J58LV).

### What's new
- ✅ Clear new plans from the comms interface when in `User Stopped` or `Locked` Franka modes as part of automatic recovery, before continuing onward.
- ✅❌ New feature is accompanied by new test: [name and description of new test].

### Related work
- ✅❌ This PR needs [link]
- ✅❌ [link] needs this PR

### TODOs / Nice-To-Haves
- ❌ [Add new unit test for new feature.]
- ❌ [Add new system test for new feature.]

### Tests
1. ✅❌ Tested on simulated robot: [Describe the tests/commands used.]
2. ✅ Tested on physical robot: Augment callback function to mimic real-world behavior (i.e., do not proceed with the callback function until a user stop is issued). Verify that the `ClearPlan` command is issued and that no motion proceeds without receipt of a plan from TLE.

### Quality
4. ✅ New code is written in pure C++17 to the best of my knowledge.
5. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
6. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
7. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
