### PR TITLE
Move pid file to somewhere that doesn't need root to write to it

### DIFF
--- a/src/driver/franka_driver.cc
+++ b/src/driver/franka_driver.cc
@@ -79,7 +79,8 @@ int do_main(std::string param_yaml, uint verbosity) {
 
 int main(int argc, char** argv) {
   // Ensure app is singleton (added by 5yler):
-  std::string pid_file = "/var/run/cobot_driver.pid";
+  std::string home_dir = getenv("HOME");
+  std::string pid_file = fmt::format("{0}/.cobot_driver.pid", home_dir);
   bool kill_existing_process = true;
   bool prompt_before_kill = false;
   uint verbosity {3};


### PR DESCRIPTION
### Background
/var/run is not writeable by normal user (or anyone other than root) so use home dir.

### What's new
- ✅ Fix driver permissions

### Tests
1. ✅ Tested on simulated robot: Verified it started up, and running a second one would kill the first.
2. ❌ Tested on physical robot: [Describe the tests/commands used.]

### Quality
3. ✅ New code is written in pure C++17 to the best of my knowledge.
4. ✅ New code follows established C++17 best practices ([C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)).
5. ✅ New code passed `clang-format` and `cpplint` at least, if not all of our static code analysers.
6. ✅ I have included Doxygen-style documentation in the new C++ code.

### Note to reviewers
Please verify that all sections are accurately filled out and that all 6 numbered entries above are present and ticked/checked off, with their requirements met, if applicable.
